### PR TITLE
Fix Arch Linux Distribution ID and correctly parse os-release files

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -98,7 +98,7 @@ let distribution = function
        | "fedora" -> Some `Fedora
        | "mageia" -> Some `Mageia
        | "gentoo" -> Some `Gentoo
-       | "archlinux" -> Some `Archlinux
+       | "arch" -> Some `Archlinux
        | s -> Some (`Other s)
      with Not_found | Failure _ -> None)
   | _ -> None


### PR DESCRIPTION
I think the invalid ID was used because older  default `/etc/issue` files contained `ArchLinux` instead of `ArchLinux`.

IMHO it's a bad idea to parse /etc/issue for os-detection. On my System it returned welcome:

```
juergen@pidsley:~/ocaml/opam-depext → opam-depext 
# Detecting depexts using flags: x86_64 linux welcome
```

because i customized this file. 

The new standardized way to detect the distribution is `the os-release` file.
Unfortunately this file is not correctly parsed in `master`. I added code to parse this file and also changed the order the order of procedures to retrieve the distribution ID:

```
1. New standard os-release files
2. Old standard lsb-release tool
3. Per-distribution release files and /etc/issue
```
