### PR TITLE
Fix centos detection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.7 (2015-07-10):
+* Fix `os-release` detection by evaluating it through a shell rather
+  than parsing the file directly.  Repairs CentOS and RHEL detection.
+
 0.6 (2015-06-25):
 * Detect already installed packages and skip them
 * Better OS detection, use `os-release`

--- a/depext.ml
+++ b/depext.ml
@@ -84,11 +84,10 @@ let distribution = function
          let os_release_files = ["/etc/os-release"; "/usr/lib/os-release"] in
          if List.exists Sys.file_exists os_release_files then
            let file = List.find Sys.file_exists os_release_files in
-           let lines = lines_of_file file in
-           let kv_list = List.fold_left (fun acc l -> match string_split '=' l with
-                                                      | k::v::[] -> (k, v)::acc
-                                                      | _ -> acc) [] lines in
-	   List.assoc "ID" kv_list
+           let cmd = Printf.sprintf "eval `cat %s` && echo $ID" file in
+           match command_output cmd with
+           | "" -> raise (Failure ("Parsing " ^ file))
+           | id -> id
          else if has_command "lsb_release" then
            command_output "lsb_release -i -s"
          else let release_file = List.find Sys.file_exists

--- a/depext.ml
+++ b/depext.ml
@@ -421,7 +421,7 @@ let command =
   Term.(pure main $ print_flags_arg $ list_arg $ short_arg $
         no_sources_arg $ debug_arg $ install_arg $ update_arg $ dryrun_arg $
         packages_arg),
-  Term.info "opam-depext" ~version:"0.6" ~doc ~man
+  Term.info "opam-depext" ~version:"0.7" ~doc ~man
 
 let () =
   match Term.eval command with

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "depext"
-version: "0.6"
+version: "0.7"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
           "Anil Madhavapeddy <anil@recoil.org>"]


### PR DESCRIPTION
Do not directly parse `os-release` to get the `ID` field.
This resulted in "centos" being parsed instead of `centos`, and
hence OS detection failing. Instead, run the `os-release` file
through a shell and echo `$ID` directly.
