### PR TITLE
0.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-sudo: required
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  - PACKAGE="opam-depext" OCAML_VERSION=latest POST_INSTALL_HOOK="opam depext async_ssl"
-  - PACKAGE="opam-depext" OCAML_VERSION=4.01   POST_INSTALL_HOOK="opam depext mirage"
-  - PACKAGE="opam-depext" OCAML_VERSION=4.00   POST_INSTALL_HOOK="opam depext ssl"
-  - PACKAGE="opam-depext" OCAML_VERSION=3.12   POST_INSTALL_HOOK="opam depext pcre"
+ global:
+   - PACKAGE="depextx"
+   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -i ssl pcre"
+ matrix:
+   - DISTRO=debian-stable OCAML_VERSION=4.01.0
+   - DISTRO=debian-testing OCAML_VERSION=4.00.1
+   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.01.0
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
+   - DISTRO=centos-6 OCAML_VERSION=4.01.0
+   - DISTRO=centos-7 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
+   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.9.1 (2016-02-22):
+* Do not assume that `bash` is installed for source depexts (#35).
+
 0.9.0 (2016-01-04):
 * Add support for Alpine Linux.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.9.1 (2016-02-22):
 * Do not assume that `bash` is installed for source depexts (#35).
 * Add support for Red Hat Enterprise Linux via `rhel` tag (#32).
+* Add multi-distro Docker-based Travis file.
 
 0.9.0 (2016-01-04):
 * Add support for Alpine Linux.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.9.1 (2016-02-22):
 * Do not assume that `bash` is installed for source depexts (#35).
+* Add support for Red Hat Enterprise Linux via `rhel` tag (#32).
 
 0.9.0 (2016-01-04):
 * Add support for Alpine Linux.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
 OPAM depext plugin
+==================
 
 Replacement for the currently used shell-scripts handling distribution-specific
 installation of OPAM packages' external dependencies (as per the `depexts` field
 in their definitions).
 
-This is a first prototype, largely incomplete ; it may help pave the way to some
-specification of the `depexts` field -- and may give some basis for a real
+Currently supported depexts are:
+
+* `homebrew` `osx`
+* `macports` `osx`
+* `debian` `linux`
+* `ubuntu` `linux`
+* `centos` `linux`
+* `fedora` `linux`
+* `rhel` `linux`
+* `mageia` `linux`
+* `alpine` `linux`
+* `archlinux` `linux`
+* `win32` `cygwin`
+* `gentoo`
+* `freebsd`
+* `openbsd`
+* `netbsd`
+* `dragonfly`
+ 
+This version runs as an OPAM plugin; it may help pave the way to some
+specification of the `depexts` field and give some basis for a real
 plugin integrating with OPAM (see
 https://github.com/ocaml/opam/blob/master/doc/design/depexts-plugins)
+
+Questions: email <opam-devel@lists.ocaml.org>

--- a/depext.ml
+++ b/depext.ml
@@ -104,6 +104,7 @@ let distribution = function
        | "gentoo" -> Some `Gentoo
        | "alpine" -> Some `Alpine
        | "arch" -> Some `Archlinux
+       | "rhel" -> Some `RHEL
        | s -> Some (`Other s)
      with Not_found | Failure _ -> None)
   | `OpenBSD -> Some `OpenBSD
@@ -137,6 +138,7 @@ let distrflags = function
   | Some `Ubuntu -> ["ubuntu"]
   | Some `Centos -> ["centos"]
   | Some `Fedora -> ["fedora"]
+  | Some `RHEL -> ["rhel"]
   | Some `Mageia -> ["mageia"]
   | Some `Alpine -> ["alpine"]
   | Some `Archlinux -> ["archlinux"]
@@ -182,7 +184,7 @@ let install_packages_commands distribution packages =
     ["port"::"install"::packages]
   | Some (`Debian | `Ubuntu) ->
     ["apt-get"::"install"::"-qq"::"-yy"::packages]
-  | Some (`Centos | `Fedora | `Mageia) ->
+  | Some (`Centos | `Fedora | `Mageia | `RHEL) ->
     ["yum"::"install"::"-y"::packages;
      "rpm"::"-q"::packages]
   | Some `FreeBSD ->
@@ -205,7 +207,7 @@ let update_command = function
      ["apt-get";"update"]
   | Some `Homebrew ->
      ["brew"; "update"]
-  | Some (`Centos | `Fedora | `Mageia) ->
+  | Some (`Centos | `Fedora | `Mageia | `RHEL) ->
      ["yum"; "-y"; "update"]
   | Some `Archlinux ->
      ["pacman"; "-S"]
@@ -238,9 +240,9 @@ let get_installed_packages distribution (packages: string list): string list =
          | [pkg;_;_;"installed"] -> pkg :: acc
          | _ -> acc)
       [] lines
-  | Some (`Centos | `Fedora | `Mageia | `Archlinux| `Gentoo | `Alpine) ->
+  | Some (`Centos | `Fedora | `Mageia | `Archlinux| `Gentoo | `Alpine | `RHEL) ->
     let query_command_prefix = match distribution with
-      | Some (`Centos | `Fedora | `Mageia) -> "rpm -qi "
+      | Some (`Centos | `Fedora | `Mageia | `RHEL) -> "rpm -qi "
       | Some `Archlinux -> "pacman -Q "
       | Some `Gentoo -> "equery list "
       | Some `Alpine -> "apk info -e "

--- a/depext.ml
+++ b/depext.ml
@@ -439,7 +439,7 @@ let command =
   Term.(pure main $ print_flags_arg $ list_arg $ short_arg $
         no_sources_arg $ debug_arg $ install_arg $ update_arg $ dryrun_arg $
         packages_arg),
-  Term.info "opam-depext" ~version:"0.9.0" ~doc ~man
+  Term.info "opam-depext" ~version:"0.9.1" ~doc ~man
 
 let () =
   match Term.eval command with

--- a/depext.ml
+++ b/depext.ml
@@ -303,9 +303,9 @@ let run_source_scripts = function
          don't need extra depexts *)
       if has_command "curl" then
         (* This still feels a bit frightening, said this way. *)
-        List.map (Printf.sprintf "curl -L \"%s\" | bash -ex -") source_urls
+        List.map (Printf.sprintf "curl -L \"%s\" | sh -ex -") source_urls
       else
-        List.map (Printf.sprintf "wget -O - \"%s\" | bash -ex -") source_urls
+        List.map (Printf.sprintf "wget -O - \"%s\" | sh -ex -") source_urls
     in
     List.iter (fun cmd ->
         match run_command [cmd] with

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "depext"
-version: "0.9.0"
+version: "0.9.1"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
           "Anil Madhavapeddy <anil@recoil.org>"]


### PR DESCRIPTION
0.9.1 (2016-02-22):
- Do not assume that `bash` is installed for source depexts (#35).
- Add support for Red Hat Enterprise Linux via `rhel` tag (#32).
- Add multi-distro Docker-based Travis file.
