### PR TITLE
Add support for `-y`, `-j <jobs>` and `-v` flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="depextx"
-   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -i ssl pcre"
+   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -i ssl && /repo/opam-depext -i -j 2 -y -v pcre"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.01.0
    - DISTRO=debian-testing OCAML_VERSION=4.00.1

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+1.0.0 (2016-02-24):
+* Add support for `-y`, `-j <jobs>` and `-v` flags when used in
+  conjunction with `opam depext -i`.  These are passed through to
+  the `opam install` command and allow non-interactive, parallel and
+  verbose output to be activated in the OPAM source builds.  This
+  conveniently allows the most common flags to `opam install` to be
+  used by an equivalent `opam depext -i` call.
+* Fix the debug printing when using `opam depext -d` to flush output
+  more often and add newlines.
+
 0.9.1 (2016-02-22):
 * Do not assume that `bash` is installed for source depexts (#35).
 * Add support for Red Hat Enterprise Linux via `rhel` tag (#32).

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ opam-depext: _build/depext.native ALWAYS
 	cp $< $@
 
 _build/%: ALWAYS
-	ocamlbuild -tags debug,use_unix -pkg cmdliner $*
+	ocamlbuild -tags annot,bin_annot,debug,use_unix -pkg cmdliner $*
 
 clean:
 	rm -rf _build opam-depext depext.native

--- a/opam
+++ b/opam
@@ -1,7 +1,8 @@
 opam-version: "1.2"
 name: "depext"
-version: "0.9.1"
-maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+version: "1.0.0"
+maintainer: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
+             "Anil Madhavapeddy <anil@recoil.org>" ]
 authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
           "Anil Madhavapeddy <anil@recoil.org>"]
 homepage: "https://github.com/ocaml/opam-depext"


### PR DESCRIPTION
These are used in conjunction with `opam depext -i` and are passed through to
the `opam install` command and allow non-interactive, parallel and verbose
output to be activated in the OPAM source builds.  This conveniently allows the
most common flags to `opam install` to be used by an equivalent
`opam depext -i` call.

Also fix the debug printing when using `opam depext -d` to flush output more
often and add newlines.
