### PR TITLE
fix FreeBSD support

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -108,6 +108,7 @@ let distribution = function
        | s -> Some (`Other s)
      with Not_found | Failure _ -> None)
   | `OpenBSD -> Some `OpenBSD
+  | `FreeBSD -> Some `FreeBSD
   | _ -> None
 
 (* generate OPAM depexts flags *)
@@ -144,6 +145,7 @@ let distrflags = function
   | Some `Archlinux -> ["archlinux"]
   | Some `Gentoo -> ["gentoo"]
   | Some `OpenBSD -> ["openbsd"]
+  | Some `FreeBSD -> ["freebsd"]
   | Some (`Other s) -> [String.lowercase s]
   | None -> []
 
@@ -256,9 +258,11 @@ let get_installed_packages distribution (packages: string list): string list =
          | Unix.WEXITED 1 -> false (* not installed *)
          | exit_status -> raise (Signaled_or_stopped (cmd, exit_status))
       ) packages
+  | Some `FreeBSD ->
+    let installed = try lines_of_command "pkg query %n" with _ -> [] in
+    List.filter (fun p -> List.mem p packages) installed
   (* todo *)
   | Some `Macports -> []
-  | Some `FreeBSD -> []
   | Some (`OpenBSD | `NetBSD) -> []
   | Some (`Other _) | None -> []
 


### PR DESCRIPTION
I am actually not sure how depext is designed, what I understand that there is the need for an architecture.  Then, a notion of operating system (still makes sense), and a distribution (which is more clearly very linux-specific).  In any case, the current state of code (esp `install_packages_command` and `get_installed_packages`) match only on the distribution.  Thus, suddenly the operating system becomes not really relevant anymore, and BSD polyvars are added as choices to the distribution type...

Could maybe someone who knows more about the code base come up with an interface file and describe a bit clearer how things are supposed to work?  I suspect that similar to `sudo`, `update` and `install` the `install_packages_command`, `update_command`, `get_installed_packages` should use both os and distribution...

Furthermore, `get_installed_packages` seems to get a list of desired packages and returns a list of packages which are desired without the actually installed ones... I'm confused, some documentation might also be useful.

In any case, this PR avoids that I've to convince opam that conf-gmp etc. is around (by fake installing it).  It used to work several months ago with an earlier version of depext, but broke in the meantime.

(I read the [initial proposal](https://github.com/ocaml/opam/blob/master/doc/design/depexts-plugins), but this barely talks about distributions and os...)
