### PR TITLE
Add raspbian as a distro synonym for Debian

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -112,7 +112,7 @@ let distribution = function
               in (List.hd (string_split ' ' (List.hd (lines_of_file release_file))))
        in
        match String.lowercase name with
-       | "debian" -> Some `Debian
+       | "debian" | "raspbian" -> Some `Debian
        | "ubuntu" -> Some `Ubuntu
        | "centos" -> Some `Centos
        | "fedora" -> Some `Fedora


### PR DESCRIPTION
Prompted by @micksulley in ocaml/opam-repository#5880.

@micksulley, if you could confirm that this fixes the problem for you, that would be fantastic.
