### PR TITLE
Add OpenSUSE depext support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
   more often and add newlines.
 * Add support for Oracle Linux via the `oraclelinux` tag.
 * Add support for Raspbian Linux via the `raspbian` tag (#41).
+* Add support for OpenSUSE via the `opensuse` tag.
 
 0.9.1 (2016-02-22):
 * Do not assume that `bash` is installed for source depexts (#35).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently supported depexts are:
 * `mageia` `linux`
 * `alpine` `linux`
 * `archlinux` `linux`
+* `opensuse` `linux`
 * `win32` `cygwin`
 * `gentoo`
 * `freebsd`

--- a/depext.ml
+++ b/depext.ml
@@ -223,7 +223,7 @@ let install_packages_commands ~interactive distribution packages =
   | Some `Alpine ->
     ["apk"::"add"::packages]
   | Some `OpenSUSE ->
-    ["zypper"::"install"::packages]
+    ["zypper"::"install"::yes ["-y"] packages]
   | Some (`Other d) ->
     fatal_error "Sorry, don't know how to install packages on your %s  system" d
   | None ->


### PR DESCRIPTION
This uses the `zypper` package manager to install depexts. Can be tested via `docker run -it ocaml/opam:opensuse bash`, and needs `opensuse` tags added to depexts in opam-repository to be useful.
