### PR TITLE
Add support for `OPAMYES` and `OPAMVERBOSE` environment variables

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+1.0.1:
+* Add support for `OPAMYES` and `OPAMVERBOSE` environment variables
+  to force `-y` and `-v` respectively.
+
 1.0.0 (2016-06-19):
 * Add support for `-y`, `-j <jobs>` and `-v` flags when used in
   conjunction with `opam depext -i`.  These are passed through to

--- a/depext.ml
+++ b/depext.ml
@@ -535,12 +535,12 @@ let opam_args =
   let docs = "OPAM OPTIONS" in
   let flags =
     List.map
-      (fun fs ->
-         let term = Arg.(value & flag_all & info ~docs fs) in
+      (fun (fs,env) ->
+         let term = Arg.(value & flag_all & info ?env ~docs fs) in
          Term.(pure (List.map (fun _ -> "--"^List.hd fs))
                $ term))
-      [ ["verbose";"v"];
-        ["yes";"y"] ]
+      [ ["verbose";"v"], (Some (Arg.env_var "OPAMVERBOSE" ~doc:"Force a verbose session"));
+        ["yes";"y"], (Some (Arg.env_var "OPAMYES" ~doc:"Force a non-interactive session")) ]
   in
   let options =
     List.map
@@ -581,7 +581,7 @@ let command =
         no_sources_arg $ debug_arg $ install_arg $ update_arg $ dryrun_arg $
         su_arg $ interactive_arg $ opam_args $
         packages_arg),
-  Term.info "opam-depext" ~version:"1.0.0" ~doc ~man
+  Term.info "opam-depext" ~version:"1.0.1" ~doc ~man
 
 let () =
   Sys.catch_break true;


### PR DESCRIPTION
to force `-y` and `-v` respectively
