### PR TITLE
Vendor cmdliner to make opam-depext dependency-free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 _build
 opam-depext
 depext.native
+shell/build.sh
+*.cmi
+*.cmo
+*.cmx
+*.cma
+*.cmxa
+*.a
+*.stamp
+src_ext/._bcdi/
+src_ext/._d/
+src_ext/._ncdi/
+src_ext/cmdliner-0.9.8.tbz
+src_ext/cmdliner/
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="depextx"
-   - POST_INSTALL_HOOK="/repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
+   - POST_INSTALL_HOOK="opam depext --version && opam depext -ui ssl && opam depext -ui -j 2 -y -v pcre"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.00.1
    - DISTRO=debian-testing OCAML_VERSION=4.01.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="depextx"
-   - POST_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
+   - POST_INSTALL_HOOK="/repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.00.1
    - DISTRO=debian-testing OCAML_VERSION=4.01.0
@@ -18,3 +18,4 @@ env:
    - DISTRO=centos-7 OCAML_VERSION=4.04.0
    - DISTRO=fedora-24 OCAML_VERSION=4.04.0
    - DISTRO=alpine OCAML_VERSION=4.05.0
+   - DISTRO=opensuse-42.2 OCAML_VERSION=4.04.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="depextx"
-   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
+   - POST_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.00.1
    - DISTRO=debian-testing OCAML_VERSION=4.01.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="depextx"
-   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -i ssl && /repo/opam-depext -i -j 2 -y -v pcre"
+   - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -ui ssl && /repo/opam-depext -ui -j 2 -y -v pcre"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.00.1
    - DISTRO=debian-testing OCAML_VERSION=4.01.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,12 @@ env:
    - PACKAGE="depextx"
    - PRE_INSTALL_HOOK="opam install -y ocamlfind && opam config exec make && /repo/opam-depext --version && /repo/opam-depext -i ssl && /repo/opam-depext -i -j 2 -y -v pcre"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.01.0
-   - DISTRO=debian-testing OCAML_VERSION=4.00.1
+   - DISTRO=debian-stable OCAML_VERSION=4.00.1
+   - DISTRO=debian-testing OCAML_VERSION=4.01.0
    - DISTRO=debian-unstable OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.01.0
-   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
    - DISTRO=centos-6 OCAML_VERSION=4.01.0
-   - DISTRO=centos-7 OCAML_VERSION=4.02.3
-   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
-   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3
+   - DISTRO=centos-7 OCAML_VERSION=4.04.0
+   - DISTRO=fedora-24 OCAML_VERSION=4.04.0
+   - DISTRO=alpine OCAML_VERSION=4.05.0

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+1.0.3 (2017-03-08):
+* Vendor in cmdliner to remove the dependency on all external
+  OCaml packages.  This lets depext always be the first in the
+  dependency order, including not needing ocamlfind or ocamlbuild.
+
 1.0.2 (2016-08-11):
 * Fix uncaught exception on empty depexts
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
-PREFIX=$(shell opam config var prefix)
 
-all: opam-depext
+all: shell/build.sh
+	cd src_ext && $(MAKE)
+	sh -ex shell/build.sh
 
-ALWAYS:
-
-opam-depext: _build/depext.native ALWAYS
-	cp $< $@
-
-_build/%: ALWAYS
-	ocamlbuild -tags annot,bin_annot,debug,use_unix -pkg cmdliner $*
+shell/build.sh: shell/build.ml
+	ocaml $< byte > $@
+	chmod a+x $@
 
 clean:
-	rm -rf _build opam-depext depext.native
+	rm -f opam-depext shell/build.sh *.cmi *.cma *.cmo *.cmx
+	cd src_ext && $(MAKE) clean
+
+distclean:
+	cd src_ext && $(MAKE) distclean
 
 install:
 	opam-installer --prefix=$(PREFIX)
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 all: shell/build.sh
 	cd src_ext && $(MAKE)
 	sh -ex shell/build.sh
@@ -17,3 +16,5 @@ distclean:
 install:
 	opam-installer --prefix=$(PREFIX)
 
+distrib:
+	cd src_ext && $(MAKE) archives

--- a/OCamlMakefile
+++ b/OCamlMakefile
@@ -1,0 +1,1299 @@
+###########################################################################
+#                              OCamlMakefile
+#                  Copyright (C) 1999-  Markus Mottl
+#
+#                             For updates see:
+#                http://www.ocaml.info/home/ocaml_sources.html
+#
+###########################################################################
+
+# Modified by damien for .glade.ml compilation
+
+# Set these variables to the names of the sources to be processed and
+# the result variable. Order matters during linkage!
+
+ifndef SOURCES
+  SOURCES := foo.ml
+endif
+export SOURCES
+
+ifndef RES_CLIB_SUF
+  RES_CLIB_SUF := _stubs
+endif
+export RES_CLIB_SUF
+
+ifndef RESULT
+  RESULT := foo
+endif
+export RESULT := $(strip $(RESULT))
+
+export LIB_PACK_NAME
+
+ifndef DOC_FILES
+  DOC_FILES := $(filter %.mli, $(SOURCES))
+endif
+export DOC_FILES
+FIRST_DOC_FILE := $(firstword $(DOC_FILES))
+
+export BCSUFFIX
+export NCSUFFIX
+
+ifndef TOPSUFFIX
+  TOPSUFFIX := .top
+endif
+export TOPSUFFIX
+
+# Eventually set include- and library-paths, libraries to link,
+# additional compilation-, link- and ocamlyacc-flags
+# Path- and library information needs not be written with "-I" and such...
+# Define THREADS if you need it, otherwise leave it unset (same for
+# USE_CAMLP4)!
+
+export THREADS
+export VMTHREADS
+export ANNOTATE
+export USE_CAMLP4
+
+export INCDIRS
+export LIBDIRS
+export EXTLIBDIRS
+export RESULTDEPS
+export OCAML_DEFAULT_DIRS
+
+export LIBS
+export CLIBS
+export CFRAMEWORKS
+
+export OCAMLFLAGS
+export OCAMLNCFLAGS
+export OCAMLBCFLAGS
+
+export OCAMLLDFLAGS
+export OCAMLNLDFLAGS
+export OCAMLBLDFLAGS
+
+export OCAMLMKLIB_FLAGS
+
+ifndef OCAMLCPFLAGS
+  OCAMLCPFLAGS := a
+endif
+export OCAMLCPFLAGS
+
+ifndef DOC_DIR
+  DOC_DIR := doc
+endif
+export DOC_DIR
+
+export PPFLAGS
+
+export LFLAGS
+export YFLAGS
+export IDLFLAGS
+
+export OCAMLDOCFLAGS
+
+export OCAMLFIND_INSTFLAGS
+
+export DVIPSFLAGS
+
+export STATIC
+
+# Add a list of optional trash files that should be deleted by "make clean"
+export TRASH
+
+ECHO := echo
+
+ifdef REALLY_QUIET
+  export REALLY_QUIET
+  ECHO := true
+  LFLAGS := $(LFLAGS) -q
+  YFLAGS := $(YFLAGS) -q
+endif
+
+####################  variables depending on your OCaml-installation
+
+SYSTEM := $(shell ocamlc -config 2>/dev/null | grep system | sed 's/system: //')
+    # This may be
+    # - mingw
+    # - mingw64
+    # - win32
+    # - cygwin
+    # - some other string means Unix
+    # - empty means ocamlc does not support -config
+
+ifeq ($(SYSTEM),$(filter $(SYSTEM),mingw mingw64))
+  MINGW=1
+endif
+ifeq ($(SYSTEM),win32)
+  MSVC=1
+endif
+
+ifdef MINGW
+  export MINGW
+  WIN32 := 1
+  # The default value 'cc' makes 'ocamlc -cc "cc"' raises the error 'The
+  # NTVDM CPU has encountered an illegal instruction'.
+  ifndef CC
+    MNO_CYGWIN := $(shell gcc -Wextra -v --help 2>/dev/null | grep -q '\-mno-cygwin'; echo $$?)
+    CC := gcc
+  else
+    MNO_CYGWIN := $(shell $$CC -Wextra -v --help 2>/dev/null | grep -q '\-mno-cygwin'; echo $$?)
+  endif
+  # We are compiling with cygwin tools:
+  ifeq ($(MNO_CYGWIN),0)
+	CFLAGS_WIN32 := -mno-cygwin
+  endif
+  # The OCaml C header files use this flag:
+  CFLAGS += -D__MINGW32__
+endif
+ifdef MSVC
+  export MSVC
+  WIN32   := 1
+  ifndef STATIC
+    CPPFLAGS_WIN32 := -DCAML_DLL
+  endif
+  CFLAGS_WIN32 += -nologo
+  EXT_OBJ := obj
+  EXT_LIB := lib
+  ifeq ($(CC),gcc)
+    # work around GNU Make default value
+    ifdef THREADS
+      CC := cl -MT
+    else
+      CC := cl
+    endif
+  endif
+  ifeq ($(CXX),g++)
+    # work around GNU Make default value
+    CXX := $(CC)
+  endif
+  CFLAG_O := -Fo
+endif
+ifdef WIN32
+  EXT_CXX := cpp
+  EXE     := .exe
+endif
+
+ifndef EXT_OBJ
+  EXT_OBJ := o
+endif
+ifndef EXT_LIB
+  EXT_LIB := a
+endif
+ifndef EXT_CXX
+  EXT_CXX := cc
+endif
+ifndef EXE
+  EXE := # empty
+endif
+ifndef CFLAG_O
+  CFLAG_O := -o # do not delete this comment (preserves trailing whitespace)!
+endif
+
+export CC
+export CXX
+export CFLAGS
+export CXXFLAGS
+export LDFLAGS
+export CPPFLAGS
+
+ifndef RPATH_FLAG
+  ifdef ELF_RPATH_FLAG
+    RPATH_FLAG := $(ELF_RPATH_FLAG)
+  else
+    RPATH_FLAG := -R
+  endif
+endif
+export RPATH_FLAG
+
+ifndef MSVC
+ifndef PIC_CFLAGS
+  PIC_CFLAGS := -fPIC
+endif
+ifndef PIC_CPPFLAGS
+  PIC_CPPFLAGS := -DPIC
+endif
+endif
+
+export PIC_CFLAGS
+export PIC_CPPFLAGS
+
+BCRESULT  := $(addsuffix $(BCSUFFIX), $(RESULT))
+NCRESULT  := $(addsuffix $(NCSUFFIX), $(RESULT))
+TOPRESULT := $(addsuffix $(TOPSUFFIX), $(RESULT))
+
+ifndef OCAMLFIND
+  OCAMLFIND := ocamlfind
+endif
+export OCAMLFIND
+
+ifndef OCAML
+  OCAML := ocaml
+endif
+export OCAML
+
+ifndef OCAMLC
+  OCAMLC := ocamlc
+endif
+export OCAMLC
+
+ifndef OCAMLOPT
+  OCAMLOPT := ocamlopt
+endif
+export OCAMLOPT
+
+ifndef OCAMLMKTOP
+  OCAMLMKTOP := ocamlmktop
+endif
+export OCAMLMKTOP
+
+ifndef OCAMLCP
+  OCAMLCP := ocamlcp
+endif
+export OCAMLCP
+
+ifndef OCAMLDEP
+  OCAMLDEP := ocamldep
+endif
+export OCAMLDEP
+
+ifndef OCAMLLEX
+  OCAMLLEX := ocamllex
+endif
+export OCAMLLEX
+
+ifndef OCAMLYACC
+  OCAMLYACC := ocamlyacc
+endif
+export OCAMLYACC
+
+ifndef OCAMLMKLIB
+  OCAMLMKLIB := ocamlmklib
+endif
+export OCAMLMKLIB
+
+ifndef OCAML_GLADECC
+  OCAML_GLADECC := lablgladecc2
+endif
+export OCAML_GLADECC
+
+ifndef OCAML_GLADECC_FLAGS
+  OCAML_GLADECC_FLAGS :=
+endif
+export OCAML_GLADECC_FLAGS
+
+ifndef CAMELEON_REPORT
+  CAMELEON_REPORT := report
+endif
+export CAMELEON_REPORT
+
+ifndef CAMELEON_REPORT_FLAGS
+  CAMELEON_REPORT_FLAGS :=
+endif
+export CAMELEON_REPORT_FLAGS
+
+ifndef CAMELEON_ZOGGY
+  CAMELEON_ZOGGY := camlp4o pa_zog.cma pr_o.cmo
+endif
+export CAMELEON_ZOGGY
+
+ifndef CAMELEON_ZOGGY_FLAGS
+  CAMELEON_ZOGGY_FLAGS :=
+endif
+export CAMELEON_ZOGGY_FLAGS
+
+ifndef OXRIDL
+  OXRIDL := oxridl
+endif
+export OXRIDL
+
+ifndef CAMLIDL
+  CAMLIDL := camlidl
+endif
+export CAMLIDL
+
+ifndef CAMLIDLDLL
+  CAMLIDLDLL := camlidldll
+endif
+export CAMLIDLDLL
+
+ifndef NOIDLHEADER
+  MAYBE_IDL_HEADER := -header
+endif
+export NOIDLHEADER
+
+export NO_CUSTOM
+
+ifndef CAMLP4
+  CAMLP4 := camlp4
+endif
+export CAMLP4
+
+ifndef REAL_OCAMLFIND
+  ifdef PACKS
+    ifndef CREATE_LIB
+      ifdef THREADS
+	PACKS += threads
+      endif
+    endif
+    empty :=
+    space := $(empty) $(empty)
+    comma := ,
+    ifdef PREDS
+      PRE_OCAML_FIND_PREDICATES := $(subst $(space),$(comma),$(PREDS))
+      PRE_OCAML_FIND_PACKAGES := $(subst $(space),$(comma),$(PACKS))
+      OCAML_FIND_PREDICATES := -predicates $(PRE_OCAML_FIND_PREDICATES)
+  #    OCAML_DEP_PREDICATES := -syntax $(PRE_OCAML_FIND_PREDICATES)
+      OCAML_FIND_PACKAGES := $(OCAML_FIND_PREDICATES) -package $(PRE_OCAML_FIND_PACKAGES)
+      OCAML_DEP_PACKAGES := $(OCAML_DEP_PREDICATES) -package $(PRE_OCAML_FIND_PACKAGES)
+    else
+      OCAML_FIND_PACKAGES := -package $(subst $(space),$(comma),$(PACKS))
+      OCAML_DEP_PACKAGES :=
+    endif
+    OCAML_FIND_LINKPKG := -linkpkg
+    REAL_OCAMLFIND := $(OCAMLFIND)
+  endif
+endif
+
+export OCAML_FIND_PACKAGES
+export OCAML_DEP_PACKAGES
+export OCAML_FIND_LINKPKG
+export REAL_OCAMLFIND
+
+ifndef OCAMLDOC
+  OCAMLDOC := ocamldoc
+endif
+export OCAMLDOC
+
+ifndef LATEX
+  LATEX := latex
+endif
+export LATEX
+
+ifndef DVIPS
+  DVIPS := dvips
+endif
+export DVIPS
+
+ifndef PS2PDF
+  PS2PDF := ps2pdf
+endif
+export PS2PDF
+
+ifndef OCAMLMAKEFILE
+  OCAMLMAKEFILE := OCamlMakefile
+endif
+export OCAMLMAKEFILE
+
+ifndef OCAMLLIBPATH
+  OCAMLLIBPATH := \
+    $(shell $(OCAMLC) 2>/dev/null -where || echo /usr/local/lib/ocaml)
+endif
+export OCAMLLIBPATH
+
+ifndef OCAML_LIB_INSTALL
+  OCAML_LIB_INSTALL := $(OCAMLLIBPATH)/contrib
+endif
+export OCAML_LIB_INSTALL
+
+###########################################################################
+
+####################  change following sections only if
+####################    you know what you are doing!
+
+# delete target files when a build command fails
+.PHONY: .DELETE_ON_ERROR
+.DELETE_ON_ERROR:
+
+# for pedants using "--warn-undefined-variables"
+export MAYBE_IDL
+export REAL_RESULT
+export CAMLIDLFLAGS
+export THREAD_FLAG
+export RES_CLIB
+export MAKEDLL
+export ANNOT_FLAG
+export C_OXRIDL
+export SUBPROJS
+export CFLAGS_WIN32
+export CPPFLAGS_WIN32
+
+INCFLAGS :=
+
+SHELL := /bin/sh
+
+MLDEPDIR := ._d
+BCDIDIR  := ._bcdi
+NCDIDIR  := ._ncdi
+
+FILTER_EXTNS := %.mli %.ml %.mll %.mly %.idl %.oxridl %.c %.m %.$(EXT_CXX) %.rep %.zog %.glade
+
+FILTERED     := $(filter $(FILTER_EXTNS), $(SOURCES))
+SOURCE_DIRS  := $(filter-out ./, $(sort $(dir $(FILTERED))))
+
+FILTERED_REP := $(filter %.rep, $(FILTERED))
+DEP_REP      := $(FILTERED_REP:%.rep=$(MLDEPDIR)/%.d)
+AUTO_REP     := $(FILTERED_REP:.rep=.ml)
+
+FILTERED_ZOG := $(filter %.zog, $(FILTERED))
+DEP_ZOG      := $(FILTERED_ZOG:%.zog=$(MLDEPDIR)/%.d)
+AUTO_ZOG     := $(FILTERED_ZOG:.zog=.ml)
+
+FILTERED_GLADE := $(filter %.glade, $(FILTERED))
+DEP_GLADE      := $(FILTERED_GLADE:%.glade=$(MLDEPDIR)/%.d)
+AUTO_GLADE     := $(FILTERED_GLADE:.glade=.ml)
+
+FILTERED_ML  := $(filter %.ml, $(FILTERED))
+DEP_ML       := $(FILTERED_ML:%.ml=$(MLDEPDIR)/%.d)
+
+FILTERED_MLI := $(filter %.mli, $(FILTERED))
+DEP_MLI      := $(FILTERED_MLI:.mli=.di)
+
+FILTERED_MLL := $(filter %.mll, $(FILTERED))
+DEP_MLL      := $(FILTERED_MLL:%.mll=$(MLDEPDIR)/%.d)
+AUTO_MLL     := $(FILTERED_MLL:.mll=.ml)
+
+FILTERED_MLY := $(filter %.mly, $(FILTERED))
+DEP_MLY      := $(FILTERED_MLY:%.mly=$(MLDEPDIR)/%.d) $(FILTERED_MLY:.mly=.di)
+AUTO_MLY     := $(FILTERED_MLY:.mly=.mli) $(FILTERED_MLY:.mly=.ml)
+
+FILTERED_IDL := $(filter %.idl, $(FILTERED))
+DEP_IDL      := $(FILTERED_IDL:%.idl=$(MLDEPDIR)/%.d) $(FILTERED_IDL:.idl=.di)
+C_IDL        := $(FILTERED_IDL:%.idl=%_stubs.c)
+ifndef NOIDLHEADER
+ C_IDL += $(FILTERED_IDL:.idl=.h)
+endif
+OBJ_C_IDL    := $(FILTERED_IDL:%.idl=%_stubs.$(EXT_OBJ))
+AUTO_IDL     := $(FILTERED_IDL:.idl=.mli) $(FILTERED_IDL:.idl=.ml) $(C_IDL)
+
+FILTERED_OXRIDL := $(filter %.oxridl, $(FILTERED))
+DEP_OXRIDL      := $(FILTERED_OXRIDL:%.oxridl=$(MLDEPDIR)/%.d) $(FILTERED_OXRIDL:.oxridl=.di)
+AUTO_OXRIDL     := $(FILTERED_OXRIDL:.oxridl=.mli) $(FILTERED_OXRIDL:.oxridl=.ml) $(C_OXRIDL)
+
+FILTERED_C_CXX := $(filter %.c %.m %.$(EXT_CXX), $(FILTERED))
+OBJ_C_CXX      := $(FILTERED_C_CXX:.c=.$(EXT_OBJ))
+OBJ_C_CXX      := $(OBJ_C_CXX:.m=.$(EXT_OBJ))
+OBJ_C_CXX      := $(OBJ_C_CXX:.$(EXT_CXX)=.$(EXT_OBJ))
+
+PRE_TARGETS  += $(AUTO_MLL) $(AUTO_MLY) $(AUTO_IDL) $(AUTO_OXRIDL) $(AUTO_ZOG) $(AUTO_REP) $(AUTO_GLADE)
+
+ALL_DEPS     := $(DEP_ML) $(DEP_MLI) $(DEP_MLL) $(DEP_MLY) $(DEP_IDL) $(DEP_OXRIDL) $(DEP_ZOG) $(DEP_REP) $(DEP_GLADE)
+
+MLDEPS       := $(filter %.d, $(ALL_DEPS))
+MLIDEPS      := $(filter %.di, $(ALL_DEPS))
+BCDEPIS      := $(MLIDEPS:%.di=$(BCDIDIR)/%.di)
+NCDEPIS      := $(MLIDEPS:%.di=$(NCDIDIR)/%.di)
+
+ALLML        := $(filter %.mli %.ml %.mll %.mly %.idl %.oxridl %.rep %.zog %.glade, $(FILTERED))
+
+IMPLO_INTF   := $(ALLML:%.mli=%.mli.__)
+IMPLO_INTF   := $(foreach file, $(IMPLO_INTF), \
+                  $(basename $(file)).cmi $(basename $(file)).cmo)
+IMPLO_INTF   := $(filter-out %.mli.cmo, $(IMPLO_INTF))
+IMPLO_INTF   := $(IMPLO_INTF:%.mli.cmi=%.cmi)
+
+IMPLX_INTF   := $(IMPLO_INTF:.cmo=.cmx)
+
+INTF         := $(filter %.cmi, $(IMPLO_INTF))
+IMPL_CMO     := $(filter %.cmo, $(IMPLO_INTF))
+IMPL_CMX     := $(IMPL_CMO:.cmo=.cmx)
+IMPL_ASM     := $(IMPL_CMO:.cmo=.asm)
+IMPL_S       := $(IMPL_CMO:.cmo=.s)
+
+OBJ_LINK     := $(OBJ_C_IDL) $(OBJ_C_CXX)
+OBJ_FILES    := $(IMPL_CMO:.cmo=.$(EXT_OBJ)) $(OBJ_LINK)
+
+EXECS        := $(addsuffix $(EXE), \
+                            $(sort $(TOPRESULT) $(BCRESULT) $(NCRESULT)))
+ifdef WIN32
+  EXECS      += $(BCRESULT).dll $(NCRESULT).dll
+endif
+
+CLIB_BASE    := $(RESULT)$(RES_CLIB_SUF)
+ifneq ($(strip $(OBJ_LINK)),)
+  RES_CLIB     := lib$(CLIB_BASE).$(EXT_LIB)
+endif
+
+ifdef WIN32
+DLLSONAME := dll$(CLIB_BASE).dll
+else
+DLLSONAME := dll$(CLIB_BASE).so
+endif
+
+NONEXECS     := $(INTF) $(IMPL_CMO) $(IMPL_CMX) $(IMPL_ASM) $(IMPL_S) \
+		$(OBJ_FILES) $(PRE_TARGETS) $(BCRESULT).cma $(NCRESULT).cmxa \
+		$(NCRESULT).$(EXT_LIB) $(BCRESULT).cmi $(BCRESULT).cmti $(BCRESULT).cmo \
+		$(NCRESULT).cmi $(NCRESULT).cmti $(NCRESULT).cmx $(NCRESULT).$(EXT_OBJ) \
+		$(RES_CLIB) $(IMPL_CMO:.cmo=.cmt) $(IMPL_CMO:.cmo=.cmti) \
+		$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmo $(LIB_PACK_NAME).cmx \
+		$(LIB_PACK_NAME).$(EXT_OBJ)
+
+ifndef STATIC
+  NONEXECS += $(DLLSONAME)
+endif
+
+ifndef LIBINSTALL_FILES
+  LIBINSTALL_FILES := $(RESULT).mli $(RESULT).cmi $(RESULT).cma \
+		      $(RESULT).cmxa $(RESULT).$(EXT_LIB) $(RES_CLIB)
+  ifndef STATIC
+    ifneq ($(strip $(OBJ_LINK)),)
+      LIBINSTALL_FILES += $(DLLSONAME)
+    endif
+  endif
+endif
+
+export LIBINSTALL_FILES
+
+ifdef WIN32
+  # some extra stuff is created while linking DLLs
+  NONEXECS   += $(BCRESULT).$(EXT_LIB) $(BCRESULT).exp $(NCRESULT).exp $(CLIB_BASE).exp $(CLIB_BASE).lib
+endif
+
+TARGETS      := $(EXECS) $(NONEXECS)
+
+# If there are IDL-files
+ifneq ($(strip $(FILTERED_IDL)),)
+  MAYBE_IDL := -cclib -lcamlidl
+endif
+
+ifdef USE_CAMLP4
+  CAMLP4PATH := \
+    $(shell $(CAMLP4) -where 2>/dev/null || echo /usr/local/lib/camlp4)
+  INCFLAGS := -I $(CAMLP4PATH)
+  CINCFLAGS := -I$(CAMLP4PATH)
+endif
+
+INCFLAGS := $(INCFLAGS) $(INCDIRS:%=-I %) $(SOURCE_DIRS:%=-I %) $(OCAML_DEFAULT_DIRS:%=-I %)
+CINCFLAGS += $(SOURCE_DIRS:%=-I%) $(INCDIRS:%=-I%) $(OCAML_DEFAULT_DIRS:%=-I%)
+
+ifndef MSVC
+  CLIBFLAGS += $(SOURCE_DIRS:%=-L%) $(LIBDIRS:%=-L%) \
+               $(EXTLIBDIRS:%=-L%) $(OCAML_DEFAULT_DIRS:%=-L%)
+
+  ifeq ($(ELF_RPATH), yes)
+    CLIBFLAGS += $(EXTLIBDIRS:%=-Wl,$(RPATH_FLAG)%)
+  endif
+endif
+
+ifndef PROFILING
+  INTF_OCAMLC := $(OCAMLC)
+else
+  ifndef THREADS
+    INTF_OCAMLC := $(OCAMLCP) -p $(OCAMLCPFLAGS)
+  else
+    # OCaml does not support profiling byte code
+    # with threads (yet), therefore we force an error.
+    ifndef REAL_OCAMLC
+      $(error Profiling of multithreaded byte code not yet supported by OCaml)
+    endif
+    INTF_OCAMLC := $(OCAMLC)
+  endif
+endif
+
+ifndef MSVC
+  COMMON_LDFLAGS := $(LDFLAGS:%=-ccopt %) $(SOURCE_DIRS:%=-ccopt -L%) \
+		    $(LIBDIRS:%=-ccopt -L%) $(EXTLIBDIRS:%=-ccopt -L%) \
+		    $(EXTLIBDIRS:%=-ccopt -Wl $(OCAML_DEFAULT_DIRS:%=-ccopt -L%))
+
+  ifeq ($(ELF_RPATH),yes)
+    COMMON_LDFLAGS += $(EXTLIBDIRS:%=-ccopt -Wl,$(RPATH_FLAG)%)
+  endif
+else
+  COMMON_LDFLAGS := -ccopt "/link -NODEFAULTLIB:LIBC $(LDFLAGS:%=%) $(SOURCE_DIRS:%=-LIBPATH:%) \
+		    $(LIBDIRS:%=-LIBPATH:%) $(EXTLIBDIRS:%=-LIBPATH:%) \
+		    $(OCAML_DEFAULT_DIRS:%=-LIBPATH:%) "
+endif
+
+CLIBS_OPTS := $(CLIBS:%=-cclib -l%) $(CFRAMEWORKS:%=-cclib '-framework %')
+ifdef MSVC
+  ifndef STATIC
+  # MSVC libraries do not have 'lib' prefix
+  CLIBS_OPTS := $(CLIBS:%=-cclib %.lib)
+  endif
+endif
+
+ifneq ($(strip $(OBJ_LINK)),)
+  ifdef CREATE_LIB
+    OBJS_LIBS := -cclib -l$(CLIB_BASE) $(CLIBS_OPTS) $(MAYBE_IDL)
+  else
+    OBJS_LIBS := $(OBJ_LINK) $(CLIBS_OPTS) $(MAYBE_IDL)
+  endif
+else
+  OBJS_LIBS := $(CLIBS_OPTS) $(MAYBE_IDL)
+endif
+
+ifdef LIB_PACK_NAME
+  FOR_PACK_NAME := $(shell echo $(LIB_PACK_NAME) | awk '{print toupper(substr($$0,1,1))substr($$0,2)}')
+endif
+
+# If we have to make byte-code
+ifndef REAL_OCAMLC
+  BYTE_OCAML := y
+
+  # EXTRADEPS is added dependencies we have to insert for all
+  # executable files we generate.  Ideally it should be all of the
+  # libraries we use, but it's hard to find the ones that get searched on
+  # the path since I don't know the paths built into the compiler, so
+  # just include the ones with slashes in their names.
+  EXTRADEPS := $(addsuffix .cma,$(foreach i,$(LIBS),$(if $(findstring /,$(i)),$(i))))
+
+
+  ifndef LIB_PACK_NAME
+    SPECIAL_OCAMLFLAGS := $(OCAMLBCFLAGS)
+  else
+    SPECIAL_OCAMLFLAGS := -for-pack $(FOR_PACK_NAME) $(OCAMLBCFLAGS)
+  endif
+
+  REAL_OCAMLC := $(INTF_OCAMLC)
+
+  REAL_IMPL := $(IMPL_CMO)
+  REAL_IMPL_INTF := $(IMPLO_INTF)
+  IMPL_SUF := .cmo
+
+  DEPFLAGS  :=
+  MAKE_DEPS := $(MLDEPS) $(BCDEPIS)
+
+  ifdef CREATE_LIB
+    override CFLAGS := $(PIC_CFLAGS) $(CFLAGS)
+    override CPPFLAGS := $(PIC_CPPFLAGS) $(CPPFLAGS)
+    ifndef STATIC
+      ifneq ($(strip $(OBJ_LINK)),)
+	MAKEDLL := $(DLLSONAME)
+	ALL_LDFLAGS := -dllib $(DLLSONAME)
+      endif
+    endif
+  endif
+
+  ifndef NO_CUSTOM
+    ifneq "$(strip $(OBJ_LINK) $(THREADS) $(MAYBE_IDL) $(CLIBS) $(CFRAMEWORKS))" ""
+      ALL_LDFLAGS += -custom
+    endif
+  endif
+
+  ALL_LDFLAGS += $(INCFLAGS) $(OCAMLLDFLAGS) $(OCAMLBLDFLAGS) \
+                 $(COMMON_LDFLAGS) $(LIBS:%=%.cma)
+  CAMLIDLDLLFLAGS :=
+
+  ifdef THREADS
+    ifdef VMTHREADS
+      THREAD_FLAG := -vmthread
+    else
+      THREAD_FLAG := -thread
+    endif
+    ALL_LDFLAGS := $(THREAD_FLAG) $(ALL_LDFLAGS)
+    ifndef CREATE_LIB
+      ifndef REAL_OCAMLFIND
+        ALL_LDFLAGS := unix.cma threads.cma $(ALL_LDFLAGS)
+      endif
+    endif
+  endif
+
+# we have to make native-code
+else
+  EXTRADEPS := $(addsuffix .cmxa,$(foreach i,$(LIBS),$(if $(findstring /,$(i)),$(i))))
+  ifndef PROFILING
+    SPECIAL_OCAMLFLAGS := $(OCAMLNCFLAGS)
+    PLDFLAGS :=
+  else
+    SPECIAL_OCAMLFLAGS := -p $(OCAMLNCFLAGS)
+    PLDFLAGS := -p
+  endif
+
+  ifndef LIB_PACK_NAME
+    SPECIAL_OCAMLFLAGS := $(OCAMLNCFLAGS)
+  else
+    SPECIAL_OCAMLFLAGS := -for-pack $(FOR_PACK_NAME) $(OCAMLNCFLAGS)
+  endif
+  REAL_IMPL := $(IMPL_CMX)
+  REAL_IMPL_INTF := $(IMPLX_INTF)
+  IMPL_SUF := .cmx
+
+  override CPPFLAGS := -DNATIVE_CODE $(CPPFLAGS)
+
+  DEPFLAGS  := -native
+  MAKE_DEPS := $(MLDEPS) $(NCDEPIS)
+
+  ALL_LDFLAGS := $(PLDFLAGS) $(INCFLAGS) $(OCAMLLDFLAGS) \
+                 $(OCAMLNLDFLAGS) $(COMMON_LDFLAGS)
+  CAMLIDLDLLFLAGS := -opt
+
+  ifndef CREATE_LIB
+    ALL_LDFLAGS += $(LIBS:%=%.cmxa)
+  else
+    override CFLAGS := $(PIC_CFLAGS) $(CFLAGS)
+    override CPPFLAGS := $(PIC_CPPFLAGS) $(CPPFLAGS)
+  endif
+
+  ifdef THREADS
+    THREAD_FLAG := -thread
+    ALL_LDFLAGS := $(THREAD_FLAG) $(ALL_LDFLAGS)
+    ifndef CREATE_LIB
+      ifndef REAL_OCAMLFIND
+        ALL_LDFLAGS := unix.cmxa threads.cmxa $(ALL_LDFLAGS)
+      endif
+    endif
+  endif
+endif
+
+export MAKE_DEPS
+
+ifdef ANNOTATE
+  ANNOT_FLAG := -annot
+else
+endif
+
+ALL_OCAMLCFLAGS := $(THREAD_FLAG) $(ANNOT_FLAG) $(OCAMLFLAGS) \
+                   $(INCFLAGS) $(SPECIAL_OCAMLFLAGS)
+
+ifdef make_deps
+  -include $(MAKE_DEPS)
+  PRE_TARGETS :=
+endif
+
+###########################################################################
+# USER RULES
+
+# Call "OCamlMakefile QUIET=" to get rid of all of the @'s.
+QUIET=@
+
+# generates byte-code (default)
+byte-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes
+bc:	byte-code
+
+byte-code-nolink:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes
+bcnl:	byte-code-nolink
+
+top:			$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(TOPRESULT) \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes
+
+# generates native-code
+
+native-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				make_deps=yes
+nc:	native-code
+
+native-code-nolink:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				make_deps=yes
+ncnl:	native-code-nolink
+
+# generates byte-code libraries
+byte-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(BCRESULT).cma \
+				REAL_RESULT="$(BCRESULT)" \
+				CREATE_LIB=yes \
+				make_deps=yes
+bcl:	byte-code-library
+
+# generates native-code libraries
+native-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(NCRESULT).cmxa \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				CREATE_LIB=yes \
+				make_deps=yes
+ncl:	native-code-library
+
+ifdef WIN32
+# generates byte-code dll
+byte-code-dll:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(BCRESULT).dll \
+				REAL_RESULT="$(BCRESULT)" \
+				make_deps=yes
+bcd:	byte-code-dll
+
+# generates native-code dll
+native-code-dll:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(NCRESULT).dll \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				make_deps=yes
+ncd:	native-code-dll
+endif
+
+# generates byte-code with debugging information
+debug-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dc:	debug-code
+
+debug-code-nolink:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dcnl:	debug-code-nolink
+
+# generates byte-code with debugging information (native code)
+debug-native-code:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
+				REAL_RESULT="$(NCRESULT)" make_deps=yes \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dnc:	debug-native-code
+
+debug-native-code-nolink:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
+				REAL_RESULT="$(NCRESULT)" make_deps=yes \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dncnl:	debug-native-code-nolink
+
+# generates byte-code libraries with debugging information
+debug-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(BCRESULT).cma \
+				REAL_RESULT="$(BCRESULT)" make_deps=yes \
+				CREATE_LIB=yes \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dcl:	debug-code-library
+
+# generates byte-code libraries with debugging information (native code)
+debug-native-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(NCRESULT).cmxa \
+				REAL_RESULT="$(NCRESULT)" make_deps=yes \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				CREATE_LIB=yes \
+				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
+				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
+dncl:	debug-native-code-library
+
+# generates byte-code for profiling
+profiling-byte-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
+				REAL_RESULT="$(BCRESULT)" PROFILING="y" \
+				make_deps=yes
+pbc:	profiling-byte-code
+
+# generates native-code
+
+profiling-native-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				PROFILING="y" \
+				make_deps=yes
+pnc:	profiling-native-code
+
+# generates byte-code libraries
+profiling-byte-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(BCRESULT).cma \
+				REAL_RESULT="$(BCRESULT)" PROFILING="y" \
+				CREATE_LIB=yes \
+				make_deps=yes
+pbcl:	profiling-byte-code-library
+
+# generates native-code libraries
+profiling-native-code-library:	$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(RES_CLIB) $(NCRESULT).cmxa \
+				REAL_RESULT="$(NCRESULT)" PROFILING="y" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				CREATE_LIB=yes \
+				make_deps=yes
+pncl:	profiling-native-code-library
+
+# packs byte-code objects
+pack-byte-code:			$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT).cmo \
+				REAL_RESULT="$(BCRESULT)" \
+				PACK_LIB=yes make_deps=yes
+pabc:	pack-byte-code
+
+# packs native-code objects
+pack-native-code:		$(PRE_TARGETS)
+			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
+				$(NCRESULT).cmx $(NCRESULT).$(EXT_OBJ) \
+				REAL_RESULT="$(NCRESULT)" \
+				REAL_OCAMLC="$(OCAMLOPT)" \
+				PACK_LIB=yes make_deps=yes
+panc:	pack-native-code
+
+# generates HTML-documentation
+htdoc:	$(DOC_DIR)/$(RESULT)/html/index.html
+
+# generates Latex-documentation
+ladoc:	$(DOC_DIR)/$(RESULT)/latex/doc.tex
+
+# generates PostScript-documentation
+psdoc:	$(DOC_DIR)/$(RESULT)/latex/doc.ps
+
+# generates PDF-documentation
+pdfdoc:	$(DOC_DIR)/$(RESULT)/latex/doc.pdf
+
+# generates all supported forms of documentation
+doc: htdoc ladoc psdoc pdfdoc
+
+###########################################################################
+# LOW LEVEL RULES
+
+$(REAL_RESULT):		$(REAL_IMPL_INTF) $(OBJ_LINK) $(EXTRADEPS) $(RESULTDEPS)
+			$(REAL_OCAMLFIND) $(REAL_OCAMLC) \
+				$(OCAML_FIND_PACKAGES) $(OCAML_FIND_LINKPKG) \
+				$(OBJS_LIBS) $(ALL_LDFLAGS) -o $@$(EXE) \
+				$(REAL_IMPL)
+
+nolink:			$(REAL_IMPL_INTF) $(OBJ_LINK)
+
+ifdef WIN32
+$(REAL_RESULT).dll:	$(REAL_IMPL_INTF) $(OBJ_LINK)
+			$(CAMLIDLDLL) $(CAMLIDLDLLFLAGS) $(OBJ_LINK) $(CLIBS) \
+				-o $@ $(REAL_IMPL)
+endif
+
+%$(TOPSUFFIX):		$(REAL_IMPL_INTF) $(OBJ_LINK) $(EXTRADEPS)
+			$(REAL_OCAMLFIND) $(OCAMLMKTOP) \
+				$(OCAML_FIND_PACKAGES) $(OCAML_FIND_LINKPKG) \
+				$(OBJS_LIBS) $(ALL_LDFLAGS) -o $@$(EXE) \
+				$(REAL_IMPL)
+
+.SUFFIXES:		.mli .ml .cmi .cmo .cmx .cma .cmxa .$(EXT_OBJ) \
+                        .mly .di .d .$(EXT_LIB) .idl %.oxridl .c .m .$(EXT_CXX) .h .so \
+                        .rep .zog .glade
+
+ifndef STATIC
+ifdef MINGW
+# From OCaml 3.11.0, ocamlmklib is available on windows
+OCAMLMLIB_EXISTS = $(shell which $(OCAMLMKLIB))
+ifeq ($(strip $(OCAMLMLIB_EXISTS)),)
+$(DLLSONAME):		$(OBJ_LINK)
+			$(CC) $(CFLAGS) $(CFLAGS_WIN32) $(OBJ_LINK) -shared -o $@ \
+			$(wildcard $(foreach dir,$(LIBDIRS),$(CLIBS:%=$(dir)/lib%.a))) \
+			 '$(OCAMLLIBPATH)/ocamlrun.a' \
+			-Wl,--whole-archive \
+			-Wl,--export-all-symbols \
+			-Wl,--allow-multiple-definition \
+			-Wl,--enable-auto-import
+else
+$(DLLSONAME):		$(OBJ_LINK)
+			$(OCAMLMKLIB) $(INCFLAGS) $(CLIBFLAGS) \
+				-o $(CLIB_BASE) $(OBJ_LINK) $(CLIBS:%=-l%) \
+				$(CFRAMEWORKS:%=-framework %) \
+				$(OCAMLMKLIB_FLAGS)
+endif
+else
+ifdef MSVC
+$(DLLSONAME):		$(OBJ_LINK)
+			link /NOLOGO /DLL /OUT:$@ $(OBJ_LINK) \
+			 $(wildcard $(foreach dir,$(LIBDIRS),$(CLIBS:%=$(dir)/%.lib))) \
+			 '$(OCAMLLIBPATH)/ocamlrun.lib'
+
+else
+$(DLLSONAME):		$(OBJ_LINK)
+			$(OCAMLMKLIB) $(INCFLAGS) $(CLIBFLAGS) \
+				-o $(CLIB_BASE) $(OBJ_LINK) $(CLIBS:%=-l%) $(CFRAMEWORKS:%=-framework %) \
+				$(OCAMLMKLIB_FLAGS)
+endif
+endif
+endif
+
+ifndef LIB_PACK_NAME
+$(RESULT).cma:		$(REAL_IMPL_INTF) $(MAKEDLL) $(EXTRADEPS) $(RESULTDEPS)
+			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(REAL_IMPL)
+
+$(RESULT).cmxa $(RESULT).$(EXT_LIB):	$(REAL_IMPL_INTF) $(EXTRADEPS) $(RESULTDEPS)
+			$(REAL_OCAMLFIND) $(OCAMLOPT) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(REAL_IMPL)
+else
+# Packing a bytecode library
+LIB_PACK_NAME_MLI = $(wildcard $(LIB_PACK_NAME).mli)
+ifeq ($(LIB_PACK_NAME_MLI),)
+LIB_PACK_NAME_CMI = $(LIB_PACK_NAME).cmi
+else
+# $(LIB_PACK_NAME).mli exists, it likely depends on other compiled interfaces
+LIB_PACK_NAME_CMI =
+$(LIB_PACK_NAME).cmi: $(REAL_IMPL_INTF)
+endif
+ifdef BYTE_OCAML
+$(LIB_PACK_NAME_CMI) $(LIB_PACK_NAME).cmo: $(REAL_IMPL_INTF)
+			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -pack -o $(LIB_PACK_NAME).cmo $(OCAMLLDFLAGS) $(REAL_IMPL)
+# Packing into a unit which can be transformed into a library
+# Remember the .ml's must have been compiled with -for-pack $(LIB_PACK_NAME)
+else
+$(LIB_PACK_NAME_CMI) $(LIB_PACK_NAME).cmx: $(REAL_IMPL_INTF)
+			$(REAL_OCAMLFIND) $(OCAMLOPT) -pack -o $(LIB_PACK_NAME).cmx  $(OCAMLLDFLAGS) $(REAL_IMPL)
+endif
+
+$(RESULT).cma:		$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmo $(MAKEDLL) $(EXTRADEPS) $(RESULTDEPS)
+			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(LIB_PACK_NAME).cmo
+
+$(RESULT).cmxa $(RESULT).$(EXT_LIB):	$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmx $(EXTRADEPS) $(RESULTDEPS)
+			$(REAL_OCAMLFIND) $(OCAMLOPT) -a $(OBJS_LIBS) $(filter-out -custom, $(ALL_LDFLAGS)) -o $@ $(LIB_PACK_NAME).cmx
+endif
+
+$(RES_CLIB): 		$(OBJ_LINK)
+ifndef MSVC
+  ifneq ($(strip $(OBJ_LINK)),)
+		      $(AR) rcs $@ $(OBJ_LINK)
+  endif
+else
+  ifneq ($(strip $(OBJ_LINK)),)
+			lib -nologo -debugtype:cv -out:$(RES_CLIB) $(OBJ_LINK)
+  endif
+endif
+
+%.cmi:	%.mli
+			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
+			if [ -z "$$pp" ]; then \
+			  $(ECHO) $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c $(THREAD_FLAG) $(ANNOT_FLAG) \
+				$(OCAMLFLAGS) $(INCFLAGS) $<; \
+			  $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c $(THREAD_FLAG) $(ANNOT_FLAG) \
+				$(OCAMLFLAGS) $(INCFLAGS) $<; \
+			else \
+			    $(ECHO) $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c -pp \"$$pp $(PPFLAGS)\" $(THREAD_FLAG) $(ANNOT_FLAG) \
+				$(OCAMLFLAGS) $(INCFLAGS) $<; \
+			    $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c -pp "$$pp $(PPFLAGS)" $(THREAD_FLAG) $(ANNOT_FLAG) \
+				$(OCAMLFLAGS) $(INCFLAGS) $<; \
+			fi
+
+%.cmi: %$(IMPL_SUF);
+
+%$(IMPL_SUF) %.$(EXT_OBJ):	%.ml
+			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
+			if [ -z "$$pp" ]; then \
+			  $(ECHO) $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c $(ALL_OCAMLCFLAGS) $<; \
+			  $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c $(ALL_OCAMLCFLAGS) $<; \
+			else \
+			  $(ECHO) $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c -pp \"$$pp $(PPFLAGS)\" $(ALL_OCAMLCFLAGS) $<; \
+			  $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
+				-c -pp "$$pp $(PPFLAGS)" $(ALL_OCAMLCFLAGS) $<; \
+			fi
+
+.PRECIOUS:		%.ml
+%.ml:			%.mll
+			$(OCAMLLEX) $(LFLAGS) $<
+
+.PRECIOUS:              %.ml %.mli
+%.ml %.mli:             %.mly
+			$(OCAMLYACC) $(YFLAGS) $<
+			$(QUIET)pp=`sed -n -e 's/.*(\*pp \([^*]*\) \*).*/\1/p;q' $<`; \
+			if [ ! -z "$$pp" ]; then \
+			  mv $*.ml $*.ml.temporary; \
+			  echo "(*pp $$pp $(PPFLAGS)*)" > $*.ml; \
+			  cat $*.ml.temporary >> $*.ml; \
+			  rm $*.ml.temporary; \
+			  mv $*.mli $*.mli.temporary; \
+			  echo "(*pp $$pp $(PPFLAGS)*)" > $*.mli; \
+			  cat $*.mli.temporary >> $*.mli; \
+			  rm $*.mli.temporary; \
+			fi
+
+
+.PRECIOUS:		%.ml
+%.ml:			%.rep
+			$(CAMELEON_REPORT) $(CAMELEON_REPORT_FLAGS) -gen $<
+
+.PRECIOUS:		%.ml
+%.ml:			%.zog
+			$(CAMELEON_ZOGGY)  $(CAMELEON_ZOGGY_FLAGS) -impl $< > $@
+
+.PRECIOUS:		%.ml
+%.ml:			%.glade
+			$(OCAML_GLADECC)  $(OCAML_GLADECC_FLAGS) $< > $@
+
+.PRECIOUS:		%.ml %.mli
+%.ml %.mli:		%.oxridl
+			$(OXRIDL) $<
+
+.PRECIOUS:		%.ml %.mli %_stubs.c %.h
+%.ml %.mli %_stubs.c %.h:		%.idl
+			$(CAMLIDL) $(MAYBE_IDL_HEADER) $(IDLFLAGS) \
+				$(CAMLIDLFLAGS) $<
+			$(QUIET)if [ $(NOIDLHEADER) ]; then touch $*.h; fi
+
+%.$(EXT_OBJ):	%.c
+			$(OCAMLC) -c -cc "$(CC)" -ccopt "$(CFLAGS) \
+				$(CPPFLAGS) $(CPPFLAGS_WIN32) \
+				$(CFLAGS_WIN32) $(CINCFLAGS) $(CFLAG_O)$@ " $<
+
+%.$(EXT_OBJ):	%.m
+			$(CC) -c $(CFLAGS) $(CINCFLAGS) $(CPPFLAGS) \
+				-I'$(OCAMLLIBPATH)' \
+				$< $(CFLAG_O)$@
+
+%.$(EXT_OBJ): %.$(EXT_CXX)
+			$(CXX) -c $(CXXFLAGS) $(CINCFLAGS) $(CPPFLAGS) \
+				-I'$(OCAMLLIBPATH)' \
+				$< $(CFLAG_O)$@
+
+$(MLDEPDIR)/%.d:	%.ml
+			$(QUIET)if [ ! -d $(@D) ]; then mkdir -p $(@D); fi
+			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
+			if [ -z "$$pp" ]; then \
+			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
+				$(INCFLAGS) $< \> $@; \
+			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
+				$(INCFLAGS) $< > $@; \
+			else \
+			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
+				-pp \"$$pp $(PPFLAGS)\" $(INCFLAGS) $< \> $@; \
+			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
+				-pp "$$pp $(PPFLAGS)" $(INCFLAGS) $< > $@; \
+			fi
+
+$(BCDIDIR)/%.di $(NCDIDIR)/%.di:	%.mli
+			$(QUIET)if [ ! -d $(@D) ]; then mkdir -p $(@D); fi
+			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
+			if [ -z "$$pp" ]; then \
+			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) $(INCFLAGS) $< \> $@; \
+			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) $(INCFLAGS) $< > $@; \
+			else \
+			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) \
+			    -pp \"$$pp $(PPFLAGS)\" $(INCFLAGS) $< \> $@; \
+			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) \
+			    -pp "$$pp $(PPFLAGS)" $(INCFLAGS) $< > $@; \
+			fi
+
+$(DOC_DIR)/$(RESULT)/html:
+	mkdir -p $@
+
+$(DOC_DIR)/$(RESULT)/html/index.html: $(DOC_DIR)/$(RESULT)/html $(DOC_FILES)
+	rm -rf $</*
+	$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $(FIRST_DOC_FILE)`; \
+	if [ -z "$$pp" ]; then \
+	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -html -d $< $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES); \
+	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -html -d $< $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES); \
+	else \
+	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp \"$$pp $(PPFLAGS)\" -html -d $< $(OCAMLDOCFLAGS) \
+	  	$(INCFLAGS) $(DOC_FILES); \
+	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp "$$pp $(PPFLAGS)" -html -d $< $(OCAMLDOCFLAGS) \
+	  	$(INCFLAGS) $(DOC_FILES); \
+	fi
+
+$(DOC_DIR)/$(RESULT)/latex:
+	mkdir -p $@
+
+$(DOC_DIR)/$(RESULT)/latex/doc.tex: $(DOC_DIR)/$(RESULT)/latex $(DOC_FILES)
+	rm -rf $</*
+	$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $(FIRST_DOC_FILE)`; \
+	if [ -z "$$pp" ]; then \
+	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -latex $(OCAMLDOCFLAGS) $(INCFLAGS) \
+	  	$(DOC_FILES) -o $@; \
+	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -latex $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES) \
+	  	-o $@; \
+	else \
+	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp \"$$pp $(PPFLAGS)\" -latex $(OCAMLDOCFLAGS) \
+	  	$(INCFLAGS) $(DOC_FILES) -o $@; \
+	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp "$$pp $(PPFLAGS)" -latex $(OCAMLDOCFLAGS) \
+	  	$(INCFLAGS) $(DOC_FILES) -o $@; \
+	fi
+
+$(DOC_DIR)/$(RESULT)/latex/doc.ps: $(DOC_DIR)/$(RESULT)/latex/doc.tex
+	cd $(DOC_DIR)/$(RESULT)/latex && \
+	  $(LATEX) doc.tex && \
+	  $(LATEX) doc.tex && \
+	  $(DVIPS) $(DVIPSFLAGS) doc.dvi -o $(@F)
+
+$(DOC_DIR)/$(RESULT)/latex/doc.pdf: $(DOC_DIR)/$(RESULT)/latex/doc.ps
+	cd $(DOC_DIR)/$(RESULT)/latex && $(PS2PDF) $(<F)
+
+define make_subproj
+.PHONY:
+subproj_$(1):
+	$$(eval $$(call PROJ_$(1)))
+	$(QUIET)if [ "$(SUBTARGET)" != "all" ]; then \
+	  $(MAKE) -f $(OCAMLMAKEFILE) $(SUBTARGET); \
+	fi
+endef
+
+$(foreach subproj,$(SUBPROJS),$(eval $(call make_subproj,$(subproj))))
+
+.PHONY:
+subprojs: $(SUBPROJS:%=subproj_%)
+
+###########################################################################
+# (UN)INSTALL RULES FOR LIBRARIES
+
+.PHONY: libinstall
+libinstall:	all
+	$(QUIET)printf "\nInstalling library with ocamlfind\n"
+	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META $(LIBINSTALL_FILES)
+	$(QUIET)printf "\nInstallation successful.\n"
+
+.PHONY: libinstall-byte-code
+libinstall-byte-code:	all
+	$(QUIET)printf "\nInstalling byte-code library with ocamlfind\n"
+	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META \
+	  $(filter-out $(RESULT).$(EXT_LIB) $(RESULT).cmxa, $(LIBINSTALL_FILES))
+	$(QUIET)printf "\nInstallation successful.\n"
+
+.PHONY: libinstall-native-code
+libinstall-native-code:	all
+	$(QUIET)printf "\nInstalling native-code library with ocamlfind\n"
+	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META \
+	  $(filter-out $(DLLSONAME) $(RESULT).cma, $(LIBINSTALL_FILES))
+	$(QUIET)printf "\nInstallation successful.\n"
+
+.PHONY: libuninstall
+libuninstall:
+	$(QUIET)printf "\nUninstalling library with ocamlfind\n"
+	$(OCAMLFIND) remove $(OCAMLFIND_INSTFLAGS) $(RESULT)
+	$(QUIET)printf "\nUninstallation successful.\n"
+
+.PHONY: rawinstall
+rawinstall:	all
+	$(QUIET)printf "\nInstalling library to: $(OCAML_LIB_INSTALL)\n"
+	-install -d $(OCAML_LIB_INSTALL)
+	for i in $(LIBINSTALL_FILES); do \
+	  if [ -f $$i ]; then \
+	    install -c -m 0644 $$i $(OCAML_LIB_INSTALL); \
+	  fi; \
+	done
+	$(QUIET)printf "\nInstallation successful.\n"
+
+.PHONY: rawuninstall
+rawuninstall:
+	$(QUIET)printf "\nUninstalling library from: $(OCAML_LIB_INSTALL)\n"
+	cd $(OCAML_LIB_INSTALL) && rm $(notdir $(LIBINSTALL_FILES))
+	$(QUIET)printf "\nUninstallation successful.\n"
+
+###########################################################################
+# MAINTENANCE RULES
+
+.PHONY:	clean
+clean::
+	rm -f $(TARGETS) $(TRASH)
+	rm -rf $(BCDIDIR) $(NCDIDIR) $(MLDEPDIR)
+
+.PHONY:	cleanup
+cleanup::
+	rm -f $(NONEXECS) $(TRASH)
+	rm -rf $(BCDIDIR) $(NCDIDIR) $(MLDEPDIR)
+
+.PHONY: clean-doc
+clean-doc::
+	rm -rf $(DOC_DIR)/$(RESULT)
+
+.PHONY: clean-all
+clean-all:: clean clean-doc
+
+.PHONY: nobackup
+nobackup:
+	rm -f *.bak *~ *.dup

--- a/depext.ml
+++ b/depext.ml
@@ -581,7 +581,7 @@ let command =
         no_sources_arg $ debug_arg $ install_arg $ update_arg $ dryrun_arg $
         su_arg $ interactive_arg $ opam_args $
         packages_arg),
-  Term.info "opam-depext" ~version:"1.0.2" ~doc ~man
+  Term.info "opam-depext" ~version:"1.0.3" ~doc ~man
 
 let () =
   Sys.catch_break true;

--- a/opam
+++ b/opam
@@ -1,6 +1,5 @@
 opam-version: "1.2"
 name: "depext"
-version: "1.0.2"
 maintainer: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
              "Anil Madhavapeddy <anil@recoil.org>" ]
 authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
@@ -9,14 +8,7 @@ homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/opam-depext.git"
-build: [
-  ["ocamlopt" "-I" cmdliner:lib "unix.cmxa" "cmdliner.cmxa"
-     "-o" "opam-depext" "depext.ml"]
-    { ocaml-native }
-  ["ocamlc" "-I" cmdliner:lib "unix.cma" "cmdliner.cma"
-     "-o" "opam-depext" "depext.ml"]
-    { !ocaml-native }
-]
-depends: [ "cmdliner" {build} ]
+build: [ make ]
+depends: [ ]
 available: [ opam-version >= "1.1.0" ]
 tags: "flags:plugin"

--- a/shell/build.ml
+++ b/shell/build.ml
@@ -1,0 +1,88 @@
+module OCaml_version : sig
+   type t
+   val v : ?patch:int -> ?extra:string -> int -> int -> t
+   val to_string : t -> string
+   val of_string : string -> t
+   val compare : t -> t -> int
+   val t : t  
+   module Since : sig
+     val bytes: t
+   end
+   module Has : sig
+     val bytes : t -> bool
+   end
+end = struct
+   type t = { major: int; minor: int; patch: int option; extra: string option }
+
+   let v ?patch ?extra major minor = { major; minor; patch; extra }
+
+   let to_string = function
+     |{major;minor;patch=None;extra=None} -> Printf.sprintf "%d.%d" major minor
+     |{major;minor;patch=Some patch;extra=None} -> Printf.sprintf "%d.%d.%d" major minor patch
+     |{major;minor;patch=Some patch;extra=Some extra} -> Printf.sprintf "%d.%d.%d+%s" major minor patch extra
+     |{major;minor;patch=None;extra=Some extra} -> Printf.sprintf "%d.%d+%s" major minor extra
+    	
+   let parse s =
+     try Scanf.sscanf s "%d.%d.%d+%s" (fun major minor patch extra -> v ~patch ~extra major minor)
+     with End_of_file | Scanf.Scan_failure _ -> begin
+       try Scanf.sscanf s "%d.%d+%s" (fun major minor extra -> v ~extra major minor)
+       with End_of_file | Scanf.Scan_failure _ -> begin
+         try Scanf.sscanf s "%d.%d.%d" (fun major minor patch -> v ~patch major minor)
+         with End_of_file | Scanf.Scan_failure _ -> begin
+           Scanf.sscanf s "%d.%d" (fun major minor -> v major minor)
+         end
+       end
+     end
+
+   let of_string s =
+     try parse s with
+     | exn ->
+        raise (Invalid_argument (Printf.sprintf "Unable to parse OCaml version '%s'" s))
+
+   let ( ++ ) x fn =
+     match x with
+     | 0 -> fn ()
+     | r -> r
+
+   let compare {major; minor; patch; extra} a =
+    compare major a.major ++ fun () ->
+    compare minor a.minor ++ fun () ->
+    compare patch a.patch ++ fun () ->
+    compare extra a.extra
+
+   let t = of_string Sys.ocaml_version
+
+   module Since = struct
+     let bytes = of_string "4.03.0"
+   end
+
+   module Has = struct
+     let bytes v =
+       match compare Since.bytes v with
+       |(-1) | 0 -> true
+       |n -> false
+   end
+
+   let test () =
+     let vers = [ "3.12.1";"3.12";"4.00.1";"4.01.0+dev-foo";"4.04.0"; "4.04+additional"; "4.05"; "4.05.0+flambda"] in
+     let vers_t = List.map parse vers in
+     let ts = List.map parse vers in
+     List.iter prerr_endline (List.map to_string ts);
+     List.iter (fun v -> Printf.eprintf "%s compared to %s: %d\n%!" (to_string t) (to_string v) (compare t v)) vers_t
+end
+
+let build_bytecode () =
+  print_endline "ocamlc -I src_ext/lib unix.cma cmdliner.cma -o opam-depext depext.ml"
+
+let build_native () =
+  print_endline "ocamlopt -I src_ext unix.cmxa cmdliner.cmxa -o opam-depext depext.ml"
+
+let usage () =
+  Printf.eprintf "Usage: ocaml build.ml [byte|native]\n\nDefaults to 'native' build.\n%!";
+  exit 1
+
+let _ =
+  match Sys.argv with
+  | [| _; "byte" |] -> build_bytecode ()
+  | [| _; "native" |] | [| _ |] -> build_native ()
+  | _ -> usage ()

--- a/shell/gen-release.sh
+++ b/shell/gen-release.sh
@@ -1,17 +1,22 @@
-#!/bin/sh
+#!/bin/sh -ex
 # Generate a release of a particular tag of opam-depext with
 # the vendor tarballs included.
 
-if [ "$1" = "" ]; then
-  echo Usage: $0 version
+v=$1
+shift
+tag=$1
+shift
+
+if [ "$tag" = "" ]; then
+  echo Usage: $0 version tag
   exit 1
 fi
 
-git archive --format=tar --prefix=opam-depext-$1/ master > ../opam-depext-$1.tar v$1
+git archive --format=tar --prefix=opam-depext-$v/ $tag > ../opam-depext-$v.tar 
 cd ..
-tar -xvf opam-depext-$1.tar
-cd opam-depext-$1
+tar -xvf opam-depext-$v.tar
+cd opam-depext-$v
 make distrib
 cd ..
-tar -jcvf opam-depext-full-$1.tbz opam-depext-$1
-rm -f opam-depext-$1.tar
+tar -jcvf opam-depext-full-$v.tbz opam-depext-$v
+rm -f opam-depext-$v.tar

--- a/shell/gen-release.sh
+++ b/shell/gen-release.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Generate a release of a particular tag of opam-depext with
+# the vendor tarballs included.
+
+if [ "$1" = "" ]; then
+  echo Usage: $0 version
+  exit 1
+fi
+
+git archive --format=tar --prefix=opam-depext-$1/ master > ../opam-depext-$1.tar v$1
+cd ..
+tar -xvf opam-depext-$1.tar
+cd opam-depext-$1
+make distrib
+cd ..
+tar -jcvf opam-depext-full-$1.tbz opam-depext-$1
+rm -f opam-depext-$1.tar

--- a/shell/md5check.ml
+++ b/shell/md5check.ml
@@ -1,0 +1,21 @@
+let file, md5 =
+  if Array.length Sys.argv <> 3 then (
+    Printf.eprintf "usage: ocaml %s <file> <md5>\n" Sys.argv.(0);
+    exit 1
+  ) else
+    Sys.argv.(1), Sys.argv.(2)
+
+let md5_of_file =
+  Digest.to_hex (Digest.file file)
+
+let () =
+  if md5 <> md5_of_file then (
+    Printf.eprintf
+      "MD5 for %s differ:\n\
+      \  expected: %s\n\
+      \    actual: %s\n"
+      file md5 md5_of_file;
+    Sys.remove file;
+    exit 1
+  ) else
+    Printf.printf "%s has the expected MD5.\n" file

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -1,0 +1,107 @@
+SHELL=bash
+FETCH=curl -OL
+OCAML=ocaml
+OCAMLC=ocamlc
+OCAMLOPT=ocamlopt
+SRC_EXTS = cmdliner 
+
+URL_cmdliner = http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.8.tbz
+MD5_cmdliner = fc67c937447cc223722f1419fa2189da
+
+ARCHIVES = $(foreach lib,$(SRC_EXTS),$(notdir $(URL_$(lib))))
+lib_of = $(foreach lib,$(SRC_EXTS),$(if $(findstring $(1),$(URL_$(lib))),$(lib),,))
+
+# Portable md5check
+MD5CHECK = $(OCAML) ../shell/md5check.ml
+
+lib-ext: clone build copy
+	@
+
+build: clone
+	[ $(OCAMLC) = no ] || $(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=bcl
+	[ $(OCAMLOPT) = no ] || $(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=ncl
+
+all: bcl ncl
+
+clone: $(SRC_EXTS:=.stamp)
+	@
+
+archives: $(SRC_EXTS:=.download)
+	@
+
+define cache_url
+https://opam.ocaml.org/2.0~dev/cache/md5/$(shell echo $(MD5_$(1)) | cut -c -2)/$(MD5_$(1))
+endef
+
+define get_from_cache
+{ $(FETCH) $(call cache_url,$(1)) && \
+  mv $(MD5_$(1)) $(notdir $(URL_$(1))) && \
+  $(MD5CHECK) $(notdir $(URL_$(1))) $(MD5_$(1)); }
+endef
+
+%.download:
+	[ -e  $(notdir $(URL_$*)) ] || \
+	$(FETCH) $(URL_$*) && $(MD5CHECK) $(notdir $(URL_$*)) $(MD5_$*) || \
+	$(call get_from_cache,$*)
+
+%.stamp: %.download
+	mkdir -p tmp
+	cd tmp && $(if $(patsubst %.tar.gz,,$(URL_$*)),bunzip2,gunzip) -c ../$(notdir $(URL_$*)) | tar x
+	rm -rf $*
+	@for ii in tmp/*; do if [ -d $${ii} ]; then mv $${ii} $*; fi; done; \
+	rm -rf tmp
+	@if [ -d patches/$* ]; then \
+          cd $* && \
+	  for p in ../patches/$*/*.patch; do \
+	    patch -p1 < $$p; \
+	  done; \
+        fi
+	@touch $@
+
+clean:
+	rm -rf lib
+	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=cleanup
+
+distclean:
+	rm -rf cmdliner
+	rm -f *.tar.gz *.tbz *.stamp
+	rm -f *.cm* *.o *.a *.lib
+	rm -rf lib
+
+LIB_EXTS = cmdliner
+
+inst_objs = cp $(1)/*.cm*i lib
+
+copy: build
+	mkdir -p lib
+	cp *.cma lib || true
+	cp *.cmxa lib || true
+	cp *.a lib || true
+	cp *.lib lib || true
+	$(call inst_objs,cmdliner/src)
+
+# --
+
+addmli = $(foreach ml,$(2),$(wildcard $(addsuffix .mli,$(basename $(1)/$(ml)))) $(1)/$(ml))
+
+SRC_cmdliner = cmdliner.ml
+
+define PROJ_cmdliner
+  SOURCES = $(call addmli,cmdliner/src,$(SRC_cmdliner))
+  RESULT = cmdliner
+  LIB_PACK_NAME =
+endef
+export PROJ_cmdliner
+
+# --
+
+ifndef SUBROJS
+  export SUBPROJS = $(LIB_EXTS)
+endif
+
+
+%:
+	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=$@
+
+OCAMLMAKEFILE = ../OCamlMakefile
+export OCAMLMAKEFILE


### PR DESCRIPTION
This will allow opam-depext to not have any external dependencies, so that it can be installed as a single binary and handle depexts for (e.g.) ocamlfind.

The PR isnt quite finished yet, as the Makefile needs support for bundled archives.  Just doing this to check what Travis thinks of it first.

It also still uses cmdliner 0.9.8, and needs an update to 1.0 (which is what prompted this PR in the first place, since there is a lot of incompatibility between the two, leading to split universe in CI)