### PR TITLE
fix #60

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -46,7 +46,7 @@ endef
 
 %.stamp: %.download
 	mkdir -p tmp
-	cd tmp && $(if $(patsubst %.tar.gz,,$(URL_$*)),bunzip2,gunzip) -c ../$(notdir $(URL_$*)) | tar x
+	cd tmp && $(if $(patsubst %.tar.gz,,$(URL_$*)),bunzip2,gunzip) -c ../$(notdir $(URL_$*)) | tar xf -
 	rm -rf $*
 	@for ii in tmp/*; do if [ -d $${ii} ]; then mv $${ii} $*; fi; done; \
 	rm -rf tmp


### PR DESCRIPTION
the | tar x contruct only works if
1. tar is a GNUtar
and
2. the compiled in default for this GNU tar contains -f-