### PR TITLE
Pass --non-interactive to zypper.

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -223,7 +223,7 @@ let install_packages_commands ~interactive distribution packages =
   | Some `Alpine ->
     ["apk"::"add"::packages]
   | Some `OpenSUSE ->
-    ["zypper"::"install"::yes ["-y"] packages]
+    ["zypper"::"install"::yes ["--non-interactive"] packages]
   | Some (`Other d) ->
     fatal_error "Sorry, don't know how to install packages on your %s  system" d
   | None ->


### PR DESCRIPTION
The openSUSE builds on `opam-repository` are [failing](https://ci.ocaml.io/log/saved/docker-build-b1bf97079c541ea9d92008f64640d12b/ddbc0b0a10cb6d5abe0a6c321147ed56399fdf31) with output like this:

```
Continue? [y/n/...? shows all options] (y): Cannot read input: bad stream or EOF.
If you run zypper without a terminal, use '--non-interactive' global
option to make zypper use default answers to prompts.
OS package update failed
```