### PR TITLE
Special case for the `epel-release` yum-package

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -581,7 +581,7 @@ let command =
         no_sources_arg $ debug_arg $ install_arg $ update_arg $ dryrun_arg $
         su_arg $ interactive_arg $ opam_args $
         packages_arg),
-  Term.info "opam-depext" ~version:"1.0.5" ~doc ~man
+  Term.info "opam-depext" ~version:"1.0.5+dev" ~doc ~man
 
 let () =
   Sys.catch_break true;


### PR DESCRIPTION
Fixes #70, (cf. also #76).

Tested with [hdf5](https://github.com/ocaml/opam-repository/blob/master/packages/hdf5/hdf5.0.1.3/opam):

```
 $ docker run -it  ocaml/opam:centos-7_ocaml-4.03.0 bash
 $ opam pin add depext 'https://github.com/smondet/opam-depext.git#epel-release-special-case'
...
 $ opam depext --version
1.0.5+dev
 $ opam depext --yes hdf5
...
 $ opam installl --yes hdf5
...
```

