### PR TITLE
Solve getting depexts of a wrong dep version (e.g. system camlp4)

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -190,7 +190,7 @@ let depexts flags opam_packages =
     else
     (* this is lighter, more general and doesn't require a lock. But only on
        newer opams *)
-    Printf.sprintf "opam list --safe --recursive --external=%s --required-by=%s"
+    Printf.sprintf "opam list --safe --recursive --external=%s --required-by=%s --installable"
       (String.concat "," flags)
       (String.concat "," opam_packages)
   in


### PR DESCRIPTION
This relies on `opam list --installable`, which can blow up opam 1.2.2, unfortunately.