### PR TITLE
Do not double-check for installed rpm packages

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -217,7 +217,7 @@ let install_packages_commands ~interactive distribution packages =
     let install_epel =
       try [
         "yum"::"install"::yes ["-y"] [List.find ((=) epel_release) packages];
-      ] with _ -> [] in
+      ] with Not_found -> [] in
     install_epel @
     ["yum"::"install"::yes ["-y"] (List.filter ((<>) epel_release) packages);
      "rpm"::"-q"::packages]

--- a/depext.ml
+++ b/depext.ml
@@ -219,8 +219,7 @@ let install_packages_commands ~interactive distribution packages =
         "yum"::"install"::yes ["-y"] [List.find ((=) epel_release) packages];
       ] with Not_found -> [] in
     install_epel @
-    ["yum"::"install"::yes ["-y"] (List.filter ((<>) epel_release) packages);
-     "rpm"::"-q"::packages]
+    ["yum"::"install"::yes ["-y"] (List.filter ((<>) epel_release) packages)]
   | Some `FreeBSD ->
     ["pkg"::"install"::packages]
   | Some (`OpenBSD | `NetBSD) ->


### PR DESCRIPTION
The mentioned behaviour in #9 seem to be not applicable anymore (checked with Fedora 25 and 27).
Fixes #80 