### PR TITLE
Fix opam file when pinned

### DIFF
--- a/opam
+++ b/opam
@@ -1,5 +1,7 @@
 opam-version: "2.0"
 name: "opam-depext"
+version: "1.1.0"
+flags: plugin
 maintainer: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "Anil Madhavapeddy <anil@recoil.org>"
@@ -8,13 +10,9 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "Anil Madhavapeddy <anil@recoil.org>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-3.0 with OCaml linking exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-depends: ["ocaml"]
-available: opam-version >= "2.0.0~beta5"
-flags: plugin
-build: make
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 synopsis: "install OS distribution packages"
 description: """
@@ -23,3 +21,18 @@ OPAM packages and the host package management system. It can query OPAM for the
 right external dependencies on a set of packages, depending on the host OS, and
 call the OS's package manager in the appropriate way to install them.
 """
+build: [
+  [make] {!pinned}
+  ["ocamlfind" "%{ocaml:native?ocamlopt:ocamlc}%"
+   "-package" "unix,cmdliner" "-linkpkg"
+    "-o" "opam-depext"
+    "depext.ml"
+  ] {pinned}
+]
+depends: [
+  "ocaml"
+  "base-unix"
+  "cmdliner" {>= "0.9.8" & dev}
+  "ocamlfind" {dev}
+]
+available: opam-version >= "2.0.0~beta5"


### PR DESCRIPTION
(cmdliner is not included in this case, and it's not valid to download it: add
a dependency)

This makes the opam file opam 2.0 only, so don't merge right away