### PR TITLE
Remove dependency on bash

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -1,4 +1,4 @@
-SHELL=bash
+SHELL=sh
 FETCH=curl -OL
 OCAML=ocaml
 OCAMLC=ocamlc


### PR DESCRIPTION
Tested on alpine with

```
opam pin add depext .
opam depext mirage
```

Signed-off-by: David Scott <dave@recoil.org>