### PR TITLE
Fix Fedora support - checking package installation

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -220,7 +220,7 @@ let install_packages_commands ~interactive distribution packages =
       ] with _ -> [] in
     install_epel @
     ["yum"::"install"::yes ["-y"] (List.filter ((<>) epel_release) packages);
-     "rpm"::"-q"::packages]
+     "rpm"::"-q"::"--whatprovides"::packages]
   | Some `FreeBSD ->
     ["pkg"::"install"::packages]
   | Some (`OpenBSD | `NetBSD) ->


### PR DESCRIPTION
Use `rpm -q --whatprovides` to handle also virtual packages. For example
`pkgconfig` is provided by `pkgconf-pkg-config` package. Installing
`pkgconfig` works just fine (installs `pkgconf-pkg-config`), but
querying with bare `rpm -q pkgconfig` fails.

This is alternative fix for #80, if you prefer to keep the check.