### PR TITLE
Add extra-source field for cmdliner.0.9.8

### DIFF
--- a/opam
+++ b/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "opam-depext"
 maintainer: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
              "Anil Madhavapeddy <anil@recoil.org>" ]
@@ -10,5 +10,9 @@ license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "https://github.com/ocaml/opam-depext.git#2.0"
 build: [ make ]
 depends: [ ]
+extra-source "src_ext/cmdliner-0.9.8.tbz" {
+  src:"http://erratique.ch/software/cmdliner/releases/cmdliner-0.9.8.tbz"
+  checksum:"fc67c937447cc223722f1419fa2189da"
+}
 available: [ opam-version >= "2.0.0~beta5" ]
 tags: "flags:plugin"


### PR DESCRIPTION
This PR fixes sandboxing & cmdliner download at build by adding its download in the `extra-source` field. As this version need an opam2, this field is handled.
Related #59 & https://github.com/ocaml/opam-depext/commit/23abbd0b95510e1f6d999555e47aba8d94df403a.