### PR TITLE
Fix arch support

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -250,7 +250,7 @@ let get_installed_packages (packages: string list): string list =
   | "centos" | "fedora" | "mageia" | "archlinux" | "gentoo" | "alpine" | "rhel" | "oraclelinux" ->
     let query_command_prefix = match distribution with
       | "centos" | "fedora" | "mageia" | "rhel" | "oraclelinux" -> ["rpm"; "-qi"]
-      | "archlinux" -> ["pacman"; "-Q"]
+      | "archlinux" | "arch" -> ["pacman"; "-Q"]
       | "gentoo" -> ["equery"; "list"]
       | "alpine" -> ["apk"; "info"; "-e"]
       | _ -> assert(false)


### PR DESCRIPTION
In my Arch system `distribution` is `arch` not `archlinux`

```sh
[/etc]> cat os-release  
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
ID_LIKE=archlinux
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
```