### PR TITLE
call su(1) with login argument 'root'

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -372,7 +372,7 @@ let sudo_run_command ~su ~interactive os distribution cmd =
         if interactive && not (ask ~default:true "Allow ?") then
           exit 1;
         if su then
-          ["su"; "-c"; Printf.sprintf "%S" (String.concat " " cmd)]
+          ["su"; "root"; "-c"; Printf.sprintf "%S" (String.concat " " cmd)]
         else
           "sudo"::cmd
       ) else cmd


### PR DESCRIPTION
Omission of the login argument in sudo_run_command will make the call to su(1)
fail on FreeBSD, NetBSD, DragonFLy, Darwin and any other UNIX where the su(1)
executable is not a GNU coreutils (derived) su.
Either because the '-c' option before the login argument defines a 'login class'
or because the '-c' option is not defined at all.

su root -c 'the command string to be executed'

will pass '-c' to the spawned shell and work on every platform.

fixes ocaml/opam-depext#51 (however newer MacOS installations tend
to have no root password set)