### PR TITLE
Treat opensuse-leap as opensuse in os-distribution

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -372,7 +372,7 @@ let sudo_run_command ~su ~interactive os distribution cmd =
         if interactive && not (ask ~default:true "Allow ?") then
           exit 1;
         if su then
-          ["su"; "-c"; Printf.sprintf "%S" (String.concat " " cmd)]
+          ["su"; "root"; "-c"; Printf.sprintf "%S" (String.concat " " cmd)]
         else
           "sudo"::cmd
       ) else cmd

--- a/depext.ml
+++ b/depext.ml
@@ -121,7 +121,7 @@ let distribution = function
        | "alpine" -> Some `Alpine
        | "arch" -> Some `Archlinux
        | "rhel" -> Some `RHEL
-       | "opensuse" -> Some `OpenSUSE
+       | "opensuse" | "opensuse-leap" -> Some `OpenSUSE
        | "ol" -> Some `OracleLinux
        | s -> Some (`Other s)
      with Not_found | Failure _ -> None)


### PR DESCRIPTION
Resolve #109.

Outputs:
```bash
opam@4846b79c61c0:/opam> cat /etc/os-release 
NAME="openSUSE Leap"
VERSION="15.0"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.0"
PRETTY_NAME="openSUSE Leap 15.0"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.0"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
opam@4846b79c61c0:/opam> ./opam-depext 
# Detecting depexts using flags: x86_64 linux opensuse
```