### PR TITLE
Use opam 2.0

### DIFF
--- a/opam
+++ b/opam
@@ -1,14 +1,15 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "depext"
 maintainer: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
              "Anil Madhavapeddy <anil@recoil.org>" ]
 authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
           "Anil Madhavapeddy <anil@recoil.org>"]
+synopsis: "Attempt to automate the installation of system packages required by OPAM packages"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0 with OCaml linking exception"
-dev-repo: "https://github.com/ocaml/opam-depext.git"
+dev-repo: "git+https://github.com/ocaml/opam-depext.git"
 build: [ make ]
 depends: [ ]
-available: [ opam-version >= "1.1.0" ]
+available: [ opam-version >= "2.0.0" ]
 tags: "flags:plugin"


### PR DESCRIPTION
This PR updates `opam` file to use `opam 2.0`.

A script `.travis-docker.sh` which used in CI uses `opam 2.0` as default, however `opam` version in this repository is `1.2`. Thus it seems all CI fail at `opam lint opam`. This PR resolves it.