### PR TITLE
fix support for newer arch linux

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -151,7 +151,7 @@ let install_packages_commands ~interactive packages =
   | "bsd" ->
     if distribution = "freebsd" then ["pkg"::"install"::packages]
     else ["pkg_add"::packages]
-  | "archlinux" ->
+  | "archlinux" | "arch" ->
     ["pacman"::"-S"::packages]
   | "gentoo" ->
     ["emerge"::packages]
@@ -169,7 +169,7 @@ let update_command = match family with
      ["brew"; "update"]
   | "rhel" | "centos" | "fedora" | "mageia" | "oraclelinux" ->
      ["yum"; "-y"; "update"]
-  | "archlinux" ->
+  | "archlinux" | "arch" ->
      ["pacman"; "-S"]
   | "gentoo" ->
      ["emerge"; "-u"]
@@ -247,7 +247,7 @@ let get_installed_packages (packages: string list): string list =
          | [pkg;_;_;"installed"] -> (try StringMap.find pkg virtual_map @ acc with Not_found -> acc)
          | _ -> acc)
       installed lines
-  | "amzn" | "centos" | "fedora" | "mageia" | "archlinux" | "gentoo" | "alpine" | "rhel" | "oraclelinux" ->
+  | "amzn" | "centos" | "fedora" | "mageia" | "archlinux" | "arch" | "gentoo" | "alpine" | "rhel" | "oraclelinux" ->
     let query_command_prefix = match distribution with
       | "amzn" | "centos" | "fedora" | "mageia" | "rhel" | "oraclelinux" -> ["rpm"; "-qi"]
       | "archlinux" | "arch" -> ["pacman"; "-Q"]


### PR DESCRIPTION
Follow up to #105, now `family` is `"arch"` too instead of `"archlinux"` on newer systems