### PR TITLE
Make package system behaviour consistent accross platforms

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -127,8 +127,8 @@ let depexts ~with_tests ~with_docs opam_packages =
   List.flatten (List.map (string_split ' ') lines)
 
 let install_packages_commands ~interactive packages =
-  let yes opt r =
-    if not interactive then opt @ r else r
+  let yes ?(no=[]) yes r =
+    if not interactive then yes @ r else no @ r
   in
   match family with
   | "homebrew" ->
@@ -151,14 +151,14 @@ let install_packages_commands ~interactive packages =
     ["yum"::"install"::yes ["-y"] (List.filter ((<>) epel_release) packages);
      "rpm"::"-q"::"--whatprovides"::packages]
   | "bsd" ->
-    if distribution = "freebsd" then ["pkg"::"install"::packages]
-    else ["pkg_add"::packages]
+    if distribution = "freebsd" then ["pkg"::"install"::yes ["-y"] packages]
+    else ["pkg_add"::yes ~no:["-I"] ["-i"] packages]
   | "archlinux" ->
-    ["pacman"::"-S"::packages]
+    ["pacman"::"-S"::yes ["--noconfirm"] packages]
   | "gentoo" ->
-    ["emerge"::packages]
+    ["emerge"::yes ~no:["-a"] [] packages]
   | "alpine" ->
-    ["apk"::"add"::packages]
+    ["apk"::"add"::yes ~no:["-i"] [] packages]
   | "suse" | "opensuse" ->
     ["zypper"::yes ["--non-interactive"] ("install"::packages)]
   | s ->

--- a/depext.ml
+++ b/depext.ml
@@ -152,7 +152,7 @@ let install_packages_commands ~interactive packages =
      "rpm"::"-q"::"--whatprovides"::packages]
   | "bsd" ->
     if distribution = "freebsd" then ["pkg"::"install"::yes ["-y"] packages]
-    else ["pkg_add"::yes ~no:["-I"] ["-i"] packages]
+    else ["pkg_add"::yes ~no:["-i"] ["-I"] packages]
   | "archlinux" ->
     ["pacman"::"-S"::yes ["--noconfirm"] packages]
   | "gentoo" ->


### PR DESCRIPTION
This is a port of https://github.com/ocaml/opam/pull/4168 back to opam-depext 2.0.

Funny enough I ran into the issue with the experimental freebsd CI in opam-repository: https://travis-ci.org/github/ocaml/opam-repository/jobs/682282143. `pkg` waited forever for an input from `<user>` (which cannot be there in CI) and the whole process failed.

So at the very least this PR should make opam-depext usable in CI on the BSDs and Archlinux.