### PR TITLE
Fix shell quotes

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -110,10 +110,6 @@ let opam_vars = [
 
 (* processing *)
 
-let cannot_escape_single_quotes s =
-  if String.contains s '\'' then
-    failwith "Quotes are forbidden in this query."
-
 let depexts ~with_tests ~with_docs opam_packages =
   let opam_version = Lazy.force opam_version in
   let recent_enough_opam =
@@ -125,13 +121,12 @@ let depexts ~with_tests ~with_docs opam_packages =
     fatal_error
       "This version of opam-depext requires opam 2.0.0~beta5 or higher";
   let c =
-    List.iter cannot_escape_single_quotes opam_packages;
     Printf.sprintf "opam list --readonly %s%s--external %s"
       (if with_tests then "--with-test " else "")
       (if with_docs then "--with-doc " else "")
       (match opam_packages with
        | [] -> ""
-       | ps -> " '--resolve=" ^ String.concat "," ps ^ "'")
+       | ps -> " " ^ Filename.quote ("--resolve=" ^ String.concat "," ps))
   in
   let s = lines_of_command c in
   let lines = List.filter (fun s -> String.length s > 0 && s.[0] <> '#') s in

--- a/depext.ml
+++ b/depext.ml
@@ -126,7 +126,7 @@ let depexts ~with_tests ~with_docs opam_packages =
       (if with_docs then "--with-doc " else "")
       (match opam_packages with
        | [] -> ""
-       | ps -> " --resolve=" ^ String.concat "," ps)
+       | ps -> " '--resolve=" ^ String.concat "," ps ^ "'")
   in
   let s = lines_of_command c in
   let lines = List.filter (fun s -> String.length s > 0 && s.[0] <> '#') s in

--- a/depext.ml
+++ b/depext.ml
@@ -110,6 +110,10 @@ let opam_vars = [
 
 (* processing *)
 
+let cannot_escape_single_quotes s =
+  if String.contains s '\'' then
+    failwith "Quotes are forbidden in this query."
+
 let depexts ~with_tests ~with_docs opam_packages =
   let opam_version = Lazy.force opam_version in
   let recent_enough_opam =
@@ -121,6 +125,7 @@ let depexts ~with_tests ~with_docs opam_packages =
     fatal_error
       "This version of opam-depext requires opam 2.0.0~beta5 or higher";
   let c =
+    List.iter cannot_escape_single_quotes opam_packages;
     Printf.sprintf "opam list --readonly %s%s--external %s"
       (if with_tests then "--with-test " else "")
       (if with_docs then "--with-doc " else "")


### PR DESCRIPTION
This PR fixes the following issue:
```
$ opam depext 'odoc>1.5.0'
# Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=debian, os-family=debian
# No extra OS packages requirements found.
# All required OS packages found.
$ ls
1.5.0
```
Would it be possible to have a urgent fix release for this? This makes `opam depext` a potential very harmful command (can overwrite users files :cry:). @rjbou @AltGr 