### PR TITLE
Force yum-based distributions to not upgrade when updating

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -177,7 +177,7 @@ let update_command = match family with
   | "homebrew" ->
      ["brew"; "update"]
   | "rhel" | "centos" | "fedora" | "mageia" | "oraclelinux" | "ol" ->
-     ["yum"; "-y"; "update"]
+     ["yum"; "makecache"]
   | "archlinux" | "arch" ->
      ["pacman"; "-Sy"]
   | "gentoo" ->


### PR DESCRIPTION
in yum, update is an alias to upgrade...

Source for solution: https://unix.stackexchange.com/questions/6252/what-is-yum-equivalent-of-apt-get-update

[only tested on oraclelinux8 for now, I need to test it elsewhere first]