### PR TITLE
archlinux: Always upgrade all the installed packages when installing a new package

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -161,7 +161,7 @@ let install_packages_commands ~interactive packages =
     else if distribution = "openbsd" then ["pkg_add"::yes ~no:["-i"] ["-I"] packages]
     else ["pkgin"::yes ["-y"] ("install"::packages)]
   | "archlinux" | "arch" ->
-    ["pacman"::"-S"::yes ["--noconfirm"] packages]
+    ["pacman"::"-Su"::yes ["--noconfirm"] packages]
   | "gentoo" ->
     ["emerge"::yes ~no:["-a"] [] packages]
   | "alpine" ->


### PR DESCRIPTION
e.g. when libc is upgraded and `opam depext -u conf-gtksourceview3` is called, pacman will not upgrade the underlying libc and will result in a link failure similar to `undefined reference to 'stat64@GLIBC_2.33'`