### PR TITLE
opam 2.1 integration

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -566,8 +566,9 @@ let command =
         $(i,--noninteractive) unless $(i,--interactive) was made explicit.";
     `S "COPYRIGHT";
     `P "$(b,opam-depext) is written by Louis Gesbert \
-        <louis.gesbert@ocamlpro.com>, copyright OCamlPro 2014-2015 with \
-        contributions from Anil Madhavapeddy, distributed under the terms of \
+        <louis.gesbert@ocamlpro.com>, copyright OCamlPro 2014-2021 with \
+        contributions from David Allsopp, Raja Boujbel, Kate Deplaix, \
+        Anil Madhavapeddy, distributed under the terms of \
         the LGPL v2.1 with linking exception. Full source available at \
         $(i,https://github.com/ocaml/opam-depext)";
     `S "BUGS";

--- a/depext.ml
+++ b/depext.ml
@@ -126,9 +126,9 @@ let run_opam ?(via=run_command ?no_stderr:None) args =
 
 let opam_query_global var =
   let opt =
-    if is_opam_2_0 () then "" else " --global "
+    if is_opam_2_0 () then "" else " --global"
   in
-  opam_output "var %s --readonly %s" var opt
+  opam_output "var %s --readonly%s" var opt
 
 let arch = opam_query_global "arch"
 let os = opam_query_global "os"

--- a/depext.ml
+++ b/depext.ml
@@ -468,7 +468,12 @@ let main print_flags list short
           let opam_install =
             "install" :: opam_packages @ opam_install_args
           in
-          if install_arg then opam_install else opam_install @ ["--depext-only"]
+          if install_arg then opam_install else
+          if interactive &&
+             not (ask ~default:true "Allow installing depexts via opam ?") then
+            exit 1
+          else
+            opam_install @ ["--depext-only"]
         in
         ignore (exec_opam opam_cmdline)))
   else

--- a/depext.ml
+++ b/depext.ml
@@ -448,11 +448,10 @@ let main print_flags list short
     (let opam_packages =
        let toreinstall =
          let pending =
-           lines_of_opam "reinstall --list-pending"
-           |> filter_map (fun nv ->
-               match string_split '.' nv with
-               | n::_ -> Some n
-               | _ -> None)
+           filter_map (fun nv ->
+             match string_split '.' nv with
+             | n::_ -> Some n
+             | _ -> None) (lines_of_opam "reinstall --list-pending")
          in
          let pin = lines_of_opam ("pin list --short") in
          List.filter (fun p -> not (List.mem p pin)) pending

--- a/depext.ml
+++ b/depext.ml
@@ -358,6 +358,11 @@ let main print_flags list short
   let with_tests_arg = checkenv "OPAMWITHTEST" with_tests_arg in
   let with_docs_arg = checkenv "OPAMWITHDOC" with_docs_arg in
   if debug_arg then debug := true;
+  if is_opam_2_1 () then
+    Printf.eprintf
+      "You are using opam 2.1, where external dependency handling has been \
+       integrated: consider calling opam directly, the 'depext' plugin \
+       interface is provided for backwards compatibility only\n";
   if print_flags then
     (if short then
        List.iter (fun (v,x) -> Printf.eprintf "%s=%s\n" v x) opam_vars

--- a/depext.ml
+++ b/depext.ml
@@ -581,7 +581,7 @@ let command =
         with_tests_arg $ with_docs_arg $
         su_arg $ interactive_arg $ opam_args $
         packages_arg),
-  Term.info "opam-depext" ~version:"1.1.2" ~doc ~man
+  Term.info "opam-depext" ~version:"1.2.0" ~doc ~man
 
 let () =
   Sys.catch_break true;

--- a/depext.ml
+++ b/depext.ml
@@ -451,18 +451,18 @@ let main print_flags list short
        opam_packages @ toreinstall
      in
      if opam_packages <> [] then
-       if update_arg then
-         (match run_opam ("update" :: "--depexts" :: opam_run_args) with
-         | Unix.WEXITED 0 ->
-           Printf.eprintf "# OS package update successful\n%!"
-         | _ -> fatal_error "OS package update failed");
-     let opam_cmdline =
-       let opam_install =
-         "install" :: opam_packages @ opam_install_args
-       in
-       if install_arg then opam_install else opam_install @ ["--depext-only"]
-     in
-     ignore (exec_opam opam_cmdline))
+       (if update_arg then
+          (match run_opam ("update" :: "--depexts" :: opam_run_args) with
+           | Unix.WEXITED 0 ->
+             Printf.eprintf "# OS package update successful\n%!"
+           | _ -> fatal_error "OS package update failed");
+        let opam_cmdline =
+          let opam_install =
+            "install" :: opam_packages @ opam_install_args
+          in
+          if install_arg then opam_install else opam_install @ ["--depext-only"]
+        in
+        ignore (exec_opam opam_cmdline)))
   else
     (let installed = get_installed_packages os_packages in
      let os_packages =

--- a/depext.ml
+++ b/depext.ml
@@ -398,7 +398,7 @@ let main print_flags list short
   install ~su ~interactive os_packages;
   let opam_cmdline = "opam"::"install":: opam_args @ opam_packages in
   if install_arg && opam_packages <> [] then begin
-    (if not short then Printf.eprintf "# Now letting OPAM install the packages\n%!");
+    (if not short then Printf.eprintf "# Now letting opam install the packages\n%!");
     let opam_cmdline = opam_cmdline @ (if with_tests_arg then ["--with-test"] else [])
       @ (if with_docs_arg then ["--with-doc"] else []) in
     (if !debug then Printf.eprintf "+ %s\n%!" (String.concat " " opam_cmdline));
@@ -410,7 +410,7 @@ open Cmdliner
 let packages_arg =
   Arg.(value & pos_all string [] &
        info ~docv:"PACKAGES"
-         ~doc:"OPAM packages to install external dependencies for. \
+         ~doc:"opam packages to install external dependencies for. \
                All installed packages if omitted" [])
 
 let print_flags_arg =
@@ -498,8 +498,8 @@ let command =
   let man = [
     `S "DESCRIPTION";
     `P "$(b,opam-depext) is a simple program intended to facilitate the \
-        interaction between OPAM packages and the host package management \
-        system. It can perform OS and distribution detection, query OPAM for \
+        interaction between opam packages and the host package management \
+        system. It can perform OS and distribution detection, query opam for \
         the right external dependencies on a set of packages, and call the OS \
         package manager in the appropriate way to install then.";
     `S "OPAM OPTIONS";
@@ -516,7 +516,7 @@ let command =
     `P "Bugs are tracked at $(i,https://github.com/ocaml/opam-depext/issues) \
         or can be reported to $(i,<opam-devel@lists.ocaml.org>).";
   ] in
-  let doc = "Query and install external dependencies of OPAM packages" in
+  let doc = "Query and install external dependencies of opam packages" in
   Term.(pure main $ print_flags_arg $ list_arg $ short_arg $
         debug_arg $ install_arg $ update_arg $ dryrun_arg $
         with_tests_arg $ with_docs_arg $

--- a/depext.ml
+++ b/depext.ml
@@ -57,6 +57,15 @@ let string_split char str =
   in
   aux 0
 
+let filter_map f =
+  let rec loop acc = function
+  | [] -> List.rev acc
+  | x :: l ->
+      match f x with
+      | None -> loop acc l
+      | Some x -> loop (x::acc) l
+  in loop []
+
 let has_command c =
   let cmd = Printf.sprintf "command -v %s >/dev/null" c in
   try Sys.command cmd = 0 with Sys_error _ -> false
@@ -440,7 +449,7 @@ let main print_flags list short
        let toreinstall =
          let pending =
            lines_of_opam "reinstall --list-pending"
-           |> List.filter_map (fun nv ->
+           |> filter_map (fun nv ->
                match string_split '.' nv with
                | n::_ -> Some n
                | _ -> None)

--- a/opam
+++ b/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 name: "opam-depext"
 version: "1.2.0"
-flags: plugin
 maintainer: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "Anil Madhavapeddy <anil@recoil.org>"
@@ -10,17 +9,17 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "Anil Madhavapeddy <anil@recoil.org>"
 ]
-license: "LGPL-3.0 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
-synopsis: "install OS distribution packages"
-description: """
-opam-depext is a simple program intended to facilitate the interaction between
-OPAM packages and the host package management system. It can query OPAM for the
-right external dependencies on a set of packages, depending on the host OS, and
-call the OS's package manager in the appropriate way to install them.
-"""
+depends: [
+  "ocaml" {>= "4.00"}
+  "base-unix"
+  "cmdliner" {>= "0.9.8" & dev}
+  "ocamlfind" {dev}
+]
+available: opam-version >= "2.0.0~beta5"
+flags: plugin
 build: [
   [make] {!pinned}
   ["ocamlfind" "%{ocaml:native?ocamlopt:ocamlc}%"
@@ -29,10 +28,11 @@ build: [
     "depext.ml"
   ] {pinned}
 ]
-depends: [
-  "ocaml"
-  "base-unix"
-  "cmdliner" {>= "0.9.8" & dev}
-  "ocamlfind" {dev}
-]
-available: opam-version >= "2.0.0~beta5"
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+synopsis: "Install OS distribution packages"
+description: """
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them.
+"""

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "opam-depext"
-version: "1.1.0"
+version: "1.2.0"
 flags: plugin
 maintainer: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"


### PR DESCRIPTION
When opam depext is called with opam 2.1, it uses opam' internal depext mechanism (by calling opam for each features). Options are kept unchanged.
fix #141 & ocaml/opam#4854