### PR TITLE
4.00.0 and 5.00.0 compatibility...

### DIFF
--- a/depext.ml
+++ b/depext.ml
@@ -79,9 +79,9 @@ let run_command ?(no_stderr=false) c =
 let ask ?(default=false) fmt =
   Printf.ksprintf (fun s ->
       Printf.printf "%s [%s] %!" s (if default then "Y/n" else "y/N");
-      try match String.lowercase (read_line ()) with
-        | "y" | "yes" -> true
-        | "n" | "no" -> false
+      try match read_line () with
+        | "y" | "Y" | "yes" | "Yes" | "yEs" | "yeS" | "YEs" | "yES" | "YeS" | "YES" -> true
+        | "n" | "N" | "no" | "nO" | "No" | "NO" -> false
         | _  -> default
       with End_of_file -> false)
     fmt

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -24,7 +24,17 @@ build: clone
 all: bcl ncl
 
 clone: $(SRC_EXTS:=.stamp)
+ifneq ($(filter 4.%,$(shell $(OCAMLC) -vnum)),)
 	@
+else
+	@mv cmdliner/src/cmdliner.ml cmdliner/src/t
+	@echo 'module String = struct include String' > cmdliner/src/cmdliner.ml
+	@echo '  let uppercase = uppercase_ascii' >> cmdliner/src/cmdliner.ml
+	@echo '  let lowercase = lowercase_ascii' >> cmdliner/src/cmdliner.ml
+	@echo '  let capitalize = capitalize_ascii' >> cmdliner/src/cmdliner.ml
+	@echo 'end' >> cmdliner/src/cmdliner.ml
+	@cat cmdliner/src/t >> cmdliner/src/cmdliner.ml
+endif
 
 archives: $(SRC_EXTS:=.download)
 	@


### PR DESCRIPTION
Slightly hideous, but at least then we don't end up with multiple versions ever installing across switches - this should "work" with both compilation modes.

Tested on 4.00.1 and 5.00.0