### PR TITLE
Fix build on bytecode-only systems

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+1.2.2 (2022-06-??):
+* Fix build on bytecode-only systems (#149 by @dra27)
+
 1.2.1 (2022-01-21):
 * Add OCaml 5.00 compatibility (#147 by @dra27)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: shell/build.sh
-	cd src_ext && $(MAKE)
+	cd src_ext && $(MAKE) OCAMLOPT=no bcl
 	sh -ex shell/build.sh
 
 shell/build.sh: shell/build.ml


### PR DESCRIPTION
The `src_ext` system attempted to build native code even when only bytecode was required.

This is surfacing with OCaml 5.0 as there are several bytecode-only architectures at the moment.